### PR TITLE
Adding initial implementation of file cache

### DIFF
--- a/nfs/CMakeLists.txt
+++ b/nfs/CMakeLists.txt
@@ -101,12 +101,13 @@ configure_file(inc/aznfsc_config.h.in inc/aznfsc_config.h)
 # aznfsclient executable.
 add_executable(${CMAKE_PROJECT_NAME}
                src/main.cpp
-	       src/nfs_client.cpp
-	       src/rpc_transport.cpp
-	       src/rpc_task.cpp
-	       src/connection.cpp
-	       src/nfs_inode.cpp
-               src/log.cpp)
+               src/nfs_client.cpp
+               src/rpc_transport.cpp
+               src/rpc_task.cpp
+               src/connection.cpp
+	           src/nfs_inode.cpp
+               src/log.cpp
+               src/file_cache.cpp)
 
 # All include directories.
 target_include_directories(${CMAKE_PROJECT_NAME}

--- a/nfs/CMakeLists.txt
+++ b/nfs/CMakeLists.txt
@@ -101,11 +101,12 @@ configure_file(inc/aznfsc_config.h.in inc/aznfsc_config.h)
 # aznfsclient executable.
 add_executable(${CMAKE_PROJECT_NAME}
                src/main.cpp
-	       src/nfs_client.cpp
-	       src/rpc_transport.cpp
-	       src/rpc_task.cpp
-	       src/connection.cpp
-               src/log.cpp)
+               src/nfs_client.cpp
+               src/rpc_transport.cpp
+               src/rpc_task.cpp
+               src/connection.cpp
+               src/log.cpp
+               src/file_cache.cpp)
 
 # All include directories.
 target_include_directories(${CMAKE_PROJECT_NAME}

--- a/nfs/CMakeLists.txt
+++ b/nfs/CMakeLists.txt
@@ -105,6 +105,7 @@ add_executable(${CMAKE_PROJECT_NAME}
 	       src/rpc_transport.cpp
 	       src/rpc_task.cpp
 	       src/connection.cpp
+	       src/nfs_inode.cpp
                src/log.cpp)
 
 # All include directories.

--- a/nfs/inc/file_cache.h
+++ b/nfs/inc/file_cache.h
@@ -1,0 +1,266 @@
+#ifndef __AZNFSC_FILE_CACHE_H__
+#define __AZNFSC_FILE_CACHE_H__
+
+#include <map>
+#include <mutex>
+#include <memory>
+
+#include <cstdint>
+#include <cassert>
+#include <vector>
+
+namespace aznfsc {
+
+// W/o jumbo blocks, 5TB is the max file size we can support.
+#define AZNFSC_MAX_FILE_SIZE    (100 * 1024 * 1024 * 50'000ULL)
+
+/*
+ * We should set fuse max_write and max_read option to 16MB.
+ * With that application read/writes will be limited to 16MB and hence the
+ * chunk size. Note that single readahead size is also limited by this, but
+ * user can always issue multiple readahead reads.
+ */
+#define AZNFSC_MAX_CHUNK_SIZE (16 * 1024 * 1024)
+
+#define AZNFSC_BAD_OFFSET (~0ull)
+
+// Forward declaration.
+class bytes_chunk_cache;
+
+/**
+ * This represents one contiguous chunk of bytes in bytes_chunk_cache.
+ * bytes_chunk_cache consists of zero or more bytes_chunk ordered by offset.
+ * Note that a byte range can be cached using one or more bytes_chunk and the
+ * size of the individual component bytes_chunk depends on the order in which
+ * the application writes data to the file.
+ * A contiguous file range cached by a series of bytes_chunk is called an
+ * "extent". Extents are important as they decide if/when we can issue full
+ * block-sized write.
+ */
+struct bytes_chunk
+{
+    // bytes_chunk_cache needs to access the private member alloc_buffer.
+    friend bytes_chunk_cache;
+
+private:
+    /*
+     * This is the actual allocated buffer. The 'buffer' member will point
+     * inside this allocated buffer. It typically points to the beginning of
+     * the buffer (aka alloc_buffer.get()) but with cache trimming, buffer can
+     * be updated and point anywhere inside the allocated buffer. Any chunk
+     * that refers to the same allocated buffer will hold a ref to alloc_buffer,
+     * so alloc_buffer will be freed when the last ref is dropped. This should
+     * typically happen when the chunk is freed.
+     */
+    std::shared_ptr<uint8_t> alloc_buffer;
+
+public:
+    // Offset from the start of file this chunk represents.
+    uint64_t offset;
+
+    /*
+     * Length of this chunk.
+     * User can safely access [buffer, buffer+length).
+     */
+    uint64_t length;
+
+    /*
+     * Start of valid cached data corresponding to this chunk.
+     * This will typically have the value alloc_buffer.get(), i.e., it points
+     * to the start of the data buffer represented by the shared pointer
+     * alloc_buffer, but if some cached data is deleted from the beginning of a
+     * chunk, causing the buffer to be "trimmed" from the beginning, this can
+     * point anywhere inside the buffer.
+     */
+    uint8_t *buffer;
+
+    /*
+     * is_empty indicates whether buffer contains valid data.
+     * It is used by the caller differently, depending on whether it wants to
+     * write/read to/from the file. For a writer it's not very significant,
+     * it simply means that this data is not currently cached. For a reader,
+     * otoh, it's significant information as it means that the data in this
+     * chunk is not valid file data and caller must ensure that the actual
+     * file data is read into it before using it. Chunks with is_empty=false
+     * need not read file data as they already have data read from the file.
+     * Obviously, the caller has to make sure that cache data is valid, i.e.,
+     * file mtime has not changed since the last time it was cached.
+     */
+    bool is_empty;
+
+    /**
+     * Constructor to create a brand new chunk with newly allocated buffer.
+     * This chunk is the sole owner of alloc_buffer and 'buffer' points to the
+     * start of allocated buffer, alloc_buffer.get(). Later as this chunk is
+     * split or returned to the caller through get(), alloc_buffer may have
+     * more owners. When the last owner releases claim alloc_buffer will be
+     * freed. This should happen when the chunk is freed.
+     *
+     * XXX: If we need to gracefully handle allocation failure, the buffer
+     *      allocation must be done by the caller.
+     *
+     * XXX Default std new[] implementation is very slow, use tcmalloc for
+     *     much faster perf. The main problem with std new is that it doesn't
+     *     use memory pools and for large allocations it gets/releases memory
+     *     to the system, which causes zero'ing overhead as kernel has to
+     *     zero pages.
+     */
+    bytes_chunk(uint64_t _offset,
+                uint64_t _length) :
+        bytes_chunk(_offset,
+                    _length,
+                    true /* is_empty */,
+                    std::shared_ptr<uint8_t>(new uint8_t[_length]))
+    {
+    }
+
+    /**
+     * Constructor to create a chunk that refers to alloc_buffer from another
+     * existing chunk. The additional _buffer parameter allows flexibility of
+     * making buffer point anywhere inside alloc_buffer.
+     * This is useful for chunks created due to splitting or when returning
+     * bytes_chunk from bytes_chunk_cache::get().
+     */
+    bytes_chunk(uint64_t _offset,
+                uint64_t _length,
+                uint8_t *_buffer,
+                const std::shared_ptr<uint8_t>& _alloc_buffer) :
+        bytes_chunk(_offset,
+                    _length,
+                    false /* is_empty */,
+                    _alloc_buffer)
+    {
+        // Update buffer as requested.
+        buffer = _buffer;
+
+        // Make sure buffer points inside the allocate buffer.
+        assert(buffer != nullptr);
+        assert(alloc_buffer != nullptr);
+        assert((buffer - alloc_buffer.get()) >= 0);
+        assert((buffer - alloc_buffer.get()) <= AZNFSC_MAX_CHUNK_SIZE);
+    }
+
+    /**
+     * The actual constructor called by all the overloads.
+     */
+    bytes_chunk(uint64_t _offset,
+                uint64_t _length,
+                bool _is_empty,
+                const std::shared_ptr<uint8_t>& _alloc_buffer) :
+        alloc_buffer(_alloc_buffer),
+        offset(_offset),
+        length(_length),
+        buffer(alloc_buffer.get()),
+        is_empty(_is_empty)
+    {
+        assert(offset < AZNFSC_MAX_FILE_SIZE);
+        // 0-sized chunks don't exist.
+        assert(length > 0);
+        assert(length <= AZNFSC_MAX_CHUNK_SIZE);
+        assert((offset + length) <= AZNFSC_MAX_FILE_SIZE);
+        assert(buffer != nullptr);
+        assert(alloc_buffer != nullptr);
+        assert(alloc_buffer.use_count() > 1);
+    }
+};
+
+/**
+ * bytes_chunk_cache::scan() can behave differently depending on the scan_action
+ * passed.
+ */
+enum class scan_action
+{
+    SCAN_ACTION_INVALID = 0,
+    SCAN_ACTION_GET,
+    SCAN_ACTION_RELEASE,
+};
+
+/**
+ * This is the per-file cache that caches variable sized extents and is
+ * indexed using byte offset and length.
+ */
+class bytes_chunk_cache
+{
+public:
+    /**
+     * Return a vector of bytes_chunk cacheing the byte range [offset, offset+length).
+     * Parts of the range that correspond to chunks already present in the
+     * cache will refer to those existing chunks, for such chunks is_empty will
+     * be set to false, while those parts of the range for which there wasn't
+     * an already cached chunk found, new chunks will be allocated and inserted
+     * into the chunkmap. These new chunks will have is_empty set to true.
+     * This means after this function successfully returns there will be
+     * chunks present in the cache for the entire range [offset, offset+length).
+     *
+     * If extent_left and extent_right are non-null, on completion, they will
+     * hold the left and right edges of the extent containing the range
+     * [offset, offset+left). Note that an extent is a collection of one or
+     * more chunks which cache contiguous bytes.
+     *
+     * This will be called by both,
+     * - writers, who want to write to the specified range in the file.
+     *   The returned chunks is a scatter list where the caller should write.
+     *   bytes_chunk::buffer is the buffer corresponding to each chunk where
+     *   caller should write bytes_chunk::length amount of data.
+     * - readers, who want to read the specified range from the file.
+     *   The returned chunks is a scatter list containing the data from the
+     *   file. Chunks with is_empty set to true indicate that we don't have
+     *   cached data for that chunk and the caller must arrange to read that
+     *   data from the file.
+     */
+    std::vector<bytes_chunk> get(uint64_t offset,
+                                 uint64_t length,
+                                 uint64_t *extent_left = nullptr,
+                                 uint64_t *extent_right = nullptr)
+    {
+        return scan(offset, length, scan_action::SCAN_ACTION_GET,
+                    extent_left, extent_right);
+    }
+
+    /**
+     * Free chunks in the range [offset, offset+length).
+     * Only chunks which are completely contained inside the range are freed,
+     * while chunks which lie partially in the range are trimmed (by updating
+     * the buffer, length and offset members). These will be freed later when
+     * a release() call causes them to contain no valid data
+     */
+    void release(uint64_t offset, uint64_t length)
+    {
+        scan(offset, length, scan_action::SCAN_ACTION_RELEASE);
+    }
+
+    /**
+     * This will run self tests to test the correctness of this class.
+     */
+    static int unit_test();
+
+private:
+    /**
+     * Scan all chunks lying in the range [offset, offset+length) and perform
+     * requested action, as described below:
+     *
+     * SCAN_ACTION_GET     -> Return list of chunks covering the requested
+     *                        range, allocating non-existent chunks and adding
+     *                        to chunkmap. If extent_left/extent_right are non
+     *                        null, they contain the left and right edge of the
+     *                        contiguous extent that contains [offset, offset+length).
+     * SCAN_ACTION_RELEASE -> Free chunks contained in the requested range.
+     */
+    std::vector<bytes_chunk> scan(uint64_t offset,
+                                  uint64_t length,
+                                  scan_action action,
+                                  uint64_t *extent_left = nullptr,
+                                  uint64_t *extent_right = nullptr);
+
+    /*
+     * std::map of bytes_chunk, indexed by the starting offset of the chunk.
+     */
+    std::map<uint64_t, struct bytes_chunk> chunkmap;
+
+    // Lock to protect chunkmap.
+    std::mutex lock;
+};
+
+}
+
+#endif /* __AZNFSC_FILE_CACHE_H__ */

--- a/nfs/inc/nfs_client.h
+++ b/nfs/inc/nfs_client.h
@@ -4,7 +4,6 @@
 #include "nfs_inode.h"
 #include "rpc_transport.h"
 #include "nfs_internal.h"
-//#include "rpc_readdir.h"
 
 extern "C" {
     /*
@@ -55,9 +54,6 @@ private:
      */
     struct rpc_task_helper *rpc_task_helper = nullptr;
 
-    // Instance of the readdirectory cache.
-    //struct readdir_cache* read_dir_cache;
-
     /*
      * Holds info about the server, queried by FSINFO.
      */
@@ -68,14 +64,10 @@ private:
      */
     struct nfs_server_stat server_stat;
 
-    nfs_client();
-#if 0
     nfs_client() :
     	transport(this)
     {
-        read_dir_cache = readdir_cache::get_instance();
     }
-#endif
 
 public:
     /*
@@ -97,12 +89,7 @@ public:
     {
         return rpc_task_helper;
     }
-#if 0
-    struct readdir_cache *get_readdir_cache()
-    {
-        return read_dir_cache;
-    }
-#endif
+
     /*
      * The user should first init the client class before using it.
      */

--- a/nfs/inc/nfs_client.h
+++ b/nfs/inc/nfs_client.h
@@ -166,7 +166,14 @@ public:
 
     void readdir(
         fuse_req_t req,
-        fuse_ino_t /* inode */,
+        fuse_ino_t inode,
+        size_t size,
+        off_t off,
+        struct fuse_file_info* file);
+
+    void readdirplus(
+        fuse_req_t req,
+        fuse_ino_t inode,
         size_t size,
         off_t off,
         struct fuse_file_info* file);

--- a/nfs/inc/nfs_client.h
+++ b/nfs/inc/nfs_client.h
@@ -56,7 +56,7 @@ private:
     struct rpc_task_helper *rpc_task_helper = nullptr;
 
     // Instance of the readdirectory cache.
-    struct readdir_cache* read_dir_cache;
+    //struct readdir_cache* read_dir_cache;
 
     /*
      * Holds info about the server, queried by FSINFO.
@@ -97,12 +97,12 @@ public:
     {
         return rpc_task_helper;
     }
-
+#if 0
     struct readdir_cache *get_readdir_cache()
     {
         return read_dir_cache;
     }
-
+#endif
     /*
      * The user should first init the client class before using it.
      */

--- a/nfs/inc/nfs_client.h
+++ b/nfs/inc/nfs_client.h
@@ -4,6 +4,7 @@
 #include "nfs_inode.h"
 #include "rpc_transport.h"
 #include "nfs_internal.h"
+//#include "rpc_readdir.h"
 
 extern "C" {
     /*
@@ -54,6 +55,9 @@ private:
      */
     struct rpc_task_helper *rpc_task_helper = nullptr;
 
+    // Instance of the readdirectory cache.
+    struct readdir_cache* read_dir_cache;
+
     /*
      * Holds info about the server, queried by FSINFO.
      */
@@ -64,10 +68,14 @@ private:
      */
     struct nfs_server_stat server_stat;
 
+    nfs_client();
+#if 0
     nfs_client() :
     	transport(this)
     {
+        read_dir_cache = readdir_cache::get_instance();
     }
+#endif
 
 public:
     /*
@@ -88,6 +96,11 @@ public:
     struct rpc_task_helper *get_rpc_task_helper()
     {
         return rpc_task_helper;
+    }
+
+    struct readdir_cache *get_readdir_cache()
+    {
+        return read_dir_cache;
     }
 
     /*

--- a/nfs/inc/nfs_inode.h
+++ b/nfs/inc/nfs_inode.h
@@ -24,11 +24,14 @@ struct nfs_inode
     // Fuse inode number.
     fuse_ino_t ino;
 
+    struct nfs_client *const client;
+
     // Pointer to the readdirectory cache.
     std::shared_ptr<readdirectory_cache> dircache_handle;
-
-    nfs_inode(const struct nfs_fh3 *filehandle):
-        ino(0)
+    
+    nfs_inode(const struct nfs_fh3 *filehandle, struct nfs_client *_client):
+        ino(0),
+         client(_client)
     {
         // Sanity assert.
         assert(filehandle->data.data_len > 50 &&
@@ -38,6 +41,12 @@ struct nfs_inode
         fh.data.data_val = new char[fh.data.data_len];
         ::memcpy(fh.data.data_val, filehandle->data.data_val, fh.data.data_len);
         dircache_handle = std::make_shared<readdirectory_cache>();
+    }
+
+    nfs_client *get_client() const
+    {
+        assert (client != nullptr);
+        return client;
     }
 
     void set_inode(fuse_ino_t _ino)
@@ -67,5 +76,7 @@ struct nfs_inode
         std::vector<directory_entry* >& results /* dir entries listed*/,
         bool& eof,
         bool skip_attr_size = false);
+
+    bool make_getattr_call(struct fattr3& attr);
 };
 #endif /* __NFS_INODE_H__ */

--- a/nfs/inc/nfs_inode.h
+++ b/nfs/inc/nfs_inode.h
@@ -44,7 +44,7 @@ struct nfs_inode
 
         ino = _ino;
     }
-
+    
     const struct nfs_fh3& get_fh() const
     {
         return fh;

--- a/nfs/inc/nfs_inode.h
+++ b/nfs/inc/nfs_inode.h
@@ -2,6 +2,7 @@
 #define __NFS_INODE_H__
 
 #include "aznfsc.h"
+#include "rpc_readdir.h"
 
 #define NFS_INODE_MAGIC *((const uint32_t *)"NFSI")
 
@@ -23,7 +24,7 @@ struct nfs_inode
     // Fuse inode number/
     fuse_ino_t ino;
 
-    // TODO: Add blob info structure.
+    std::shared_ptr<readdirectory_cache> dircache_handle;
 
     nfs_inode(const struct nfs_fh3 *filehandle):
         ino(0)
@@ -35,6 +36,7 @@ struct nfs_inode
         fh.data.data_len = filehandle->data.data_len;
         fh.data.data_val = new char[fh.data.data_len];
         ::memcpy(fh.data.data_val, filehandle->data.data_val, fh.data.data_len);
+        dircache_handle = std::make_shared<readdirectory_cache>();
     }
 
     void set_inode(fuse_ino_t _ino)
@@ -49,5 +51,32 @@ struct nfs_inode
     {
         return fh;
     }
+
+    bool purge_readdircache_if_required();
+
+    void purge();
+
+    void lookup_readdircache(
+        cookie3 cookie_ /* offset in the directory from which the directory should be listed*/,
+        size_t max_size /* maximum size of entries to be returned*/,
+        std::vector<directory_entry* >& results /* dir entries listed*/,
+        bool& eof,
+        bool skip_attr_size = false);
+
+
+#if 0
+    const cookieverf3* get_cookieverf() const
+    {
+        return &cookieverf;
+    }
+
+    void set_cookieverf(const cookieverf3* cokieverf)
+    {
+        if (cokieverf != nullptr)
+        {
+            ::memcpy(&cookieverf, cokieverf, sizeof(cookieverf));
+        }
+    }
+#endif
 };
 #endif /* __NFS_INODE_H__ */

--- a/nfs/inc/nfs_inode.h
+++ b/nfs/inc/nfs_inode.h
@@ -21,9 +21,10 @@ struct nfs_inode
     // NFSv3 filehandle returned by the server.
     nfs_fh3 fh;
 
-    // Fuse inode number/
+    // Fuse inode number.
     fuse_ino_t ino;
 
+    // Pointer to the readdirectory cache.
     std::shared_ptr<readdirectory_cache> dircache_handle;
 
     nfs_inode(const struct nfs_fh3 *filehandle):
@@ -46,7 +47,7 @@ struct nfs_inode
 
         ino = _ino;
     }
-    
+
     const struct nfs_fh3& get_fh() const
     {
         return fh;
@@ -56,27 +57,15 @@ struct nfs_inode
 
     void purge();
 
+    /*
+     * This function populates the \p results vector by fetching the entries from
+     * readdirectory cache starting at offset \p cookie upto size \p max_size.
+     */
     void lookup_readdircache(
-        cookie3 cookie_ /* offset in the directory from which the directory should be listed*/,
+        cookie3 cookie /* offset in the directory from which the directory should be listed*/,
         size_t max_size /* maximum size of entries to be returned*/,
         std::vector<directory_entry* >& results /* dir entries listed*/,
         bool& eof,
         bool skip_attr_size = false);
-
-
-#if 0
-    const cookieverf3* get_cookieverf() const
-    {
-        return &cookieverf;
-    }
-
-    void set_cookieverf(const cookieverf3* cokieverf)
-    {
-        if (cokieverf != nullptr)
-        {
-            ::memcpy(&cookieverf, cokieverf, sizeof(cookieverf));
-        }
-    }
-#endif
 };
 #endif /* __NFS_INODE_H__ */

--- a/nfs/inc/rpc_readdir.h
+++ b/nfs/inc/rpc_readdir.h
@@ -1,0 +1,498 @@
+#ifndef __READDIR_RPC_TASK__
+#define __READDIR_RPC_TASK__
+
+#include "aznfsc.h"
+#include <map>
+#include <shared_mutex>
+#include <vector>
+#include <ctime>
+
+//struct directory_list_cache;
+//struct directory_entry;
+
+struct directory_entry
+{
+#if 0
+    cookie3 cookie;
+    struct stat attributes;
+    nfs_inode* nfs_ino;
+    char* name;
+#endif
+    const cookie3 cookie;
+    const struct stat attributes;
+    const nfs_inode* const nfs_ino;
+    const char* const name;
+
+    directory_entry(const char* name_, cookie3 cookie_, struct stat attr, nfs_inode* nfs_ino_):
+        cookie(cookie_),
+        attributes(attr),
+        nfs_ino(nfs_ino_),
+        name(name_)
+    {}
+
+// Get the size of the directory entry
+    size_t get_size()
+    {
+        return strlen(name) + offsetof(struct directory_entry, name);
+    }
+};
+
+
+struct directory_list_cache
+{
+private:
+    const fuse_ino_t inode;
+    
+    /*
+     * This will be set if we have read all the entries of the directory
+     * from the backend.
+     */
+    bool eof;
+
+    const std::time_t create_time;
+
+    // The time at which we checked the directory mtime by making getattr call.
+    std::time_t last_mtimecheck;
+    
+    cookieverf3 cookie_verifier;
+    
+    // TODO: See if we can just make it a vector and can be indexed by cookie.
+    std::map<cookie3, struct directory_entry*> dir_entries;
+
+    std::shared_mutex lock_dirlistcache;
+
+public:
+    directory_list_cache(fuse_ino_t ino):
+        inode(ino),
+        eof(false),
+        create_time(std::time(nullptr)),
+        last_mtimecheck(std::time(nullptr))
+    {
+        assert(dir_entries.empty());
+        ::memset(&cookie_verifier, 0, sizeof(cookie_verifier));
+    }
+
+    std::shared_mutex& get_lock()
+    {
+        return lock_dirlistcache;
+    }
+
+    /*
+     * Return true and populates the \p dirent if the entry corresponding to \p cookie exists.
+     * Returns false otherwise.
+     */
+    bool get_entry_at(cookie3 cookie, struct directory_entry** dirent)
+    {
+        // Take shared lock on the map.
+        std::shared_lock<std::shared_mutex> lock(lock_dirlistcache);
+        auto it = dir_entries.find(cookie);
+
+        if (it != dir_entries.end())
+        {
+            *dirent = it->second;
+            return true;
+        }
+
+        return false;
+    }
+
+    /*
+     * Updates the last_mtimecheck to now.
+     */
+    void set_mtime()
+    {
+        // TODO: Put this behind a lock or make it atomic.
+        last_mtimecheck = std::time(nullptr);
+    }
+
+    std::time_t get_lastmtime()
+    {
+        // TODO: Make this atomic or put it under lock.
+        return last_mtimecheck;
+    }
+
+    bool add(struct directory_entry* entry)
+    {
+        assert(entry != nullptr);
+        // if (get_cache_size() < MAX_ALLOWED_SIZE) // TODO: Add this check later.
+        {
+            // Get exclusive lock on the map to add the entry to the map.
+            std::unique_lock<std::shared_mutex> lock(lock_dirlistcache);
+
+            const auto& it = dir_entries.insert({entry->cookie, entry});
+
+            return it.second;
+        }
+
+        /*
+         * TODO: Prune the map for space constraint.
+         * For now we will just not add entry into the cache if it is full.
+         */
+        return false;
+    }
+
+    const cookieverf3* get_cookieverf() const
+    {
+        return &cookie_verifier;
+    }
+
+    bool get_eof() const
+    {
+        return eof;
+    }
+
+    void set_cookieverf(const cookieverf3* cokieverf)
+    {
+        assert(cokieverf != nullptr);
+
+        // TODO: Can this be made atomic? Get exclusive lock to update the cookie verifier.
+        std::unique_lock<std::shared_mutex> lock(lock_dirlistcache);
+
+        ::memcpy(&cookie_verifier, cokieverf, sizeof(cookie_verifier));
+    }
+
+    void set_eof()
+    {
+        eof = true;
+    }
+
+    bool lookup(cookie3 cookie_, struct directory_entry** entry)
+    {
+        *entry = nullptr;
+
+        // Take shared look to see if the entry exist in the cache.
+        std::shared_lock<std::shared_mutex> lock(lock_dirlistcache);
+
+        auto it = dir_entries.find(cookie_);
+
+        if (it != dir_entries.end())
+        {
+            // TODO: See if we need to update the last access time.
+            *entry = it->second;
+            return true;
+        }
+
+        return false;
+    }
+
+    ~directory_list_cache()
+    {
+        AZLogInfo(" ~directory_list_cache() called");
+        // This cache has now become invalid. clean it up.
+        std::unique_lock<std::shared_mutex> lock(lock_dirlistcache);
+
+        for (auto it = dir_entries.begin(); it != dir_entries.end(); ++it)
+        {
+            free(it->second);
+        }
+
+        dir_entries.clear();
+    }
+};
+
+static bool are_mtimes_equal(const struct stat* attr1, const struct stat* attr2)
+{
+// #TODO : Added only for testing. Remove this!!
+return true;
+        static int i =0;
+        if (++i % 5 == 0)
+            return true;
+         else
+            return false;
+
+    if (attr1 == nullptr || attr2 == nullptr) {
+        //        std::cerr << "One of the attributes is null." << std::endl;
+        return false;
+    }
+    return (attr1->st_mtim.tv_sec == attr2->st_mtim.tv_sec) &&
+           (attr1->st_mtim.tv_nsec == attr2->st_mtim.tv_nsec);
+}
+
+/*
+ * This is the readdir map which contains a map of the readdir listing
+ * corresponding to a inode.
+ */
+struct readdir_cache
+{
+private:
+    std::map<fuse_ino_t, std::shared_ptr<directory_list_cache>> m_readdirmap;
+
+    std::shared_mutex m_lockreaddirmap;
+
+    // nfs client instance to which this cache belongs.
+    const nfs_client* nfsclient;
+
+    readdir_cache(const nfs_client* nfsclient_):
+        nfsclient(nfsclient_)
+    {}
+
+public:
+    static struct readdir_cache* get_instance(const nfs_client* nfsclient)
+    {
+        static readdir_cache rcache(nfsclient);
+        return &rcache;
+    }
+
+    bool make_getattr_call(fuse_ino_t inode, struct stat& attr)
+    {
+        // TODO: Populate this function.
+        return true;
+    }
+
+    // Purge the entry corresponding to ino
+    void purge(fuse_ino_t inode)
+    {
+        // Take exclusive lock to purge the cache.
+        std::unique_lock<std::shared_mutex> lock(m_lockreaddirmap);
+        const auto it = m_readdirmap.find(inode);
+        if (it !=  m_readdirmap.end())
+        {
+            /*
+             * Note: If someone is already holding a ref to this shared pointer, they will
+             * continue to use it till it goes out of scope.
+             */
+            m_readdirmap.erase(it);
+        }
+    }
+
+    // Checks if the cache entry should be purged. Returns true if purging is done.
+    bool purge_cache_if_required(fuse_ino_t inode)
+    {
+        // TODO: Just pass inode and get the shared ptr from find.
+        std::shared_ptr<directory_list_cache> dircache_handle;
+        {
+            // Taske sahred lock to see if the entry already exists.
+            std::shared_lock<std::shared_mutex> lock(m_lockreaddirmap);
+            const auto it = m_readdirmap.find(inode);
+            if (it !=  m_readdirmap.end())
+            {
+                // Return the entry if it exists in the map.
+                dircache_handle = it->second;
+            }
+            else
+            {
+                // No entry in the cache, no point in purgin.
+                return false;
+            }
+        }
+
+        struct directory_entry* dirent = nullptr;
+        bool success = false;
+        struct stat attr;
+
+        /*
+         * For now the only prune condition check is the directory mtime.
+         * This function can later be extended to add more conditions.
+         */
+        bool should_update_mtime = false;
+        {
+            // Take a shared lock to see if the last_mtime_check is greater than 30 secs.
+            //std::shared_lock<std::shared_mutex> lock(dircache_handle->get_lock());
+
+            bool found = dircache_handle->get_entry_at(1 /* cookie*/, &dirent); // cookie 1 represent '.', hence this gets us cached dir mtime.
+            if (!found)
+            {
+                /*
+                 * cookie = 0 refers to the current directory '.'.
+                 * This entry should never be purged from the cache, else we will not know the cached
+                 * directory mtime.
+                 * If we encounter such a state, just purge the complete cache and proceed.
+                 */
+                goto purge_cache;
+            }
+
+            const std::time_t now = std::time(nullptr);
+            const std::time_t last_mtimecheck = dircache_handle->get_lastmtime();
+            assert (now >= last_mtimecheck);
+            if (std::difftime(now, last_mtimecheck) > 30) /*sec. TODO: Add #define for this */
+            {
+                should_update_mtime = true;
+            }
+            else
+            {
+                // No need to do any mtime check, just return.
+                return false;
+            }
+        }
+
+        if (should_update_mtime)
+        {
+            success = make_getattr_call(inode, attr);
+            // Issue a getattr call to the server to fetch the directory mtime.
+        }
+
+        if (success)
+        {
+            // std::shared_lock<std::shared_mutex> lock(dircache_handle->get_lock());
+            if (!are_mtimes_equal(&dirent->attributes, &attr))
+            {
+                /*
+                * Purge the cache since the directory mtime has changed/
+                * THis indicates that the directory has changed.
+                */
+                goto purge_cache;
+            }
+
+            // Update the mtime.
+            dircache_handle->set_mtime();
+            return false;
+        }
+        else
+        {
+            // TODO: What should we do if getattr call fails?
+            return false;
+        }
+
+purge_cache:
+        purge(inode);
+        return true;
+    }
+
+
+    /*
+     * This method gets a directory handle to the directory_list_cache into which the
+     * directory entries are inserted.
+     * If the handle exists, it returns the existing handle, else it creates a new handle
+     * and returns this newly created handle.
+     * THe caller owning this handle should take appropriate lock before accessing the
+     * shared pointer members.
+     */
+    std::shared_ptr<directory_list_cache> get(fuse_ino_t inode)
+    {
+        // Check if the cache should be purged.
+        purge_cache_if_required(inode);
+
+        {
+            // Taske sahred lock to see if the entry already exists.
+            std::shared_lock<std::shared_mutex> lock(m_lockreaddirmap);
+            const auto it = m_readdirmap.find(inode);
+            if (it !=  m_readdirmap.end())
+            {
+                // Return the entry if it exists in the map.
+                return it->second;
+            }
+        }
+
+        /*
+         * If we reach here, it means the entry corresponding to the inode does not exist.
+         * We will create a new entry in the map and then return the directory_list_cache poitner.
+         */
+
+        std::shared_ptr<directory_list_cache> dirlistcache_handle =
+            std::make_shared<directory_list_cache>(inode);
+
+        // Take an exclusive lock to insert the entry to the map.
+        std::unique_lock<std::shared_mutex> lock(m_lockreaddirmap);
+        auto it = m_readdirmap.insert({inode, dirlistcache_handle});
+
+        /*
+         * There is the chance that the above insert can fail if another thread inserts
+         * the entry by the time we upgrade from shared_lock to exclusive_lock on the map.
+         */
+        if (!it.second)
+        {
+            const auto iter = m_readdirmap.find(inode);
+            assert(iter != m_readdirmap.end());
+            return iter->second;
+        }
+
+        return dirlistcache_handle;
+    }
+
+#if 0
+    bool add(fuse_ino_t inode, std::shared_ptr<directory_list_cache> dir_cache)
+    {
+        // Take exclusive lock to add the entry to the cache.
+        std::unique_lock<std::shared_mutex> lock(m_lockreaddirmap);
+//         std::shared_ptr<directory_list_cache> dir_cache_sp(dir_cache);
+        const auto& it = m_readdirmap.insert({inode, dir_cache});
+        return it.second;
+    }
+#endif
+    /*
+     * This function lists directory entries corresponding to the inode.
+     * It looks into the cache to list entries starting from cookie \p cookie_ and
+     * fills the entry into \p results upto max size \pmax_size.
+     * Note: This will only fetch the entries from the cache and does not do a backend call.
+     */
+    void lookup(
+        fuse_ino_t inode /* dir inode for which readdir call is requested */,
+        cookie3 cookie_ /* offset in the directory from which the directory should be listed*/,
+        size_t max_size /* maximum size of entries to be returned*/,
+        std::vector<directory_entry* >& results /* dir entries listed*/,
+        size_t& result_size /* size of the directory entries being returned*/,
+        bool& eof)
+    {
+        result_size = 0;
+
+        // Check if the cache should be purged.
+        purge_cache_if_required(inode);
+
+        std::shared_ptr<directory_list_cache> dir_cache_handle;
+        {
+            // Take a shared lock on the map.
+            std::shared_lock<std::shared_mutex> lock(m_lockreaddirmap);
+
+            auto it = m_readdirmap.find(inode);
+            if (it != m_readdirmap.end())
+            {
+                dir_cache_handle = it->second;
+            }
+            else
+            {
+                // There is no entry corresponding to this inode in the cache.
+                return;
+                //return false;
+            }
+
+            /*
+             * Note: The shared-lock on the m_readdirmap is released here, as we already have obtained the
+             *       shared_ptr on the directory_list_cache entry. So we basically have a shared pointer to access
+             *       the directory entries and we do not have to block access to other directory listing.
+             */
+        }
+
+        size_t rem_size = max_size;
+        //bool dir_present_in_cache = false;
+        while (rem_size > 0)
+        {
+            struct directory_entry* entry;
+            bool found = dir_cache_handle->lookup(cookie_, &entry);
+            if (found)
+            {
+         //       dir_present_in_cache = true;
+                const size_t curr_entry_size = entry->get_size();
+                if (rem_size >= curr_entry_size)
+                {
+                    result_size += curr_entry_size;
+                    results.push_back(entry);
+                }
+                else
+                {
+                    // We have populated the maximum entries requested, hence break.
+                    break;
+                }
+                rem_size -= curr_entry_size;
+                cookie_++;
+            }
+            else
+            {
+                /*
+                 * If we don't find the current cookie, then we will not find the next
+                 * ones as well since they are stored sequentially.
+                 */
+                return;
+                //return false;
+            }
+        }
+
+        eof = dir_cache_handle->get_eof();
+
+        /*
+         * NOTE: We will not populate the cookie verifier here nor access it since
+         * that will be done only at the time the readdir call is made to the backend.
+         */
+        //return dir_present_in_cache;
+    }
+};
+#endif /* __READDIR_RPC_TASK__ */

--- a/nfs/inc/rpc_readdir.h
+++ b/nfs/inc/rpc_readdir.h
@@ -10,7 +10,7 @@
 // 1GB
 #define MAX_CACHE_SIZE_LIMIT 1073741824
 
-//struct directory_list_cache;
+//struct readdirectory_cache;
 //struct directory_entry;
 
 struct directory_entry
@@ -23,7 +23,7 @@ struct directory_entry
 #endif
     const cookie3 cookie;
     const struct stat attributes;
-    const nfs_inode* const nfs_ino;
+    const struct nfs_inode* const nfs_ino;
     const char* const name;
 
     directory_entry(const char* name_, cookie3 cookie_, struct stat attr, nfs_inode* nfs_ino_):
@@ -47,11 +47,11 @@ struct directory_entry
     }
 };
 
-struct directory_list_cache
+struct readdirectory_cache
 {
 private:
-    const fuse_ino_t inode;
-    
+    //const fuse_ino_t inode;
+
     /*
      * This will be set if we have read all the entries of the directory
      * from the backend.
@@ -60,26 +60,28 @@ private:
 
     size_t cache_size;
 
-    const std::time_t create_time;
+//    const std::time_t create_time;
 
     // The time at which we checked the directory mtime by making getattr call.
     std::time_t last_mtimecheck;
-    
+    //std::atomic<std::time_t> last_mtimecheck;
+
     cookieverf3 cookie_verifier;
-    
+
     // TODO: See if we can just make it a vector and can be indexed by cookie.
     std::map<cookie3, struct directory_entry*> dir_entries;
 
     std::shared_mutex lock_dirlistcache;
 
 public:
-    directory_list_cache(fuse_ino_t ino):
-        inode(ino),
+    readdirectory_cache():
+      //  inode(ino),
         eof(false),
         cache_size(0),
-        create_time(std::time(nullptr)),
+  //      create_time(std::time(nullptr)),
         last_mtimecheck(std::time(nullptr))
     {
+        //AZLogDebug("In readdirectory_cache() constr");
         assert(dir_entries.empty());
         ::memset(&cookie_verifier, 0, sizeof(cookie_verifier));
     }
@@ -115,12 +117,14 @@ public:
     {
         // TODO: Put this behind a lock or make it atomic.
         last_mtimecheck = std::time(nullptr);
+        // last_mtimecheck.store(std::time(nullptr));
     }
 
     std::time_t get_lastmtime()
     {
         // TODO: Make this atomic or put it under lock.
         return last_mtimecheck;
+        //return last_mtimecheck.load();
     }
 
     bool add(struct directory_entry* entry)
@@ -134,7 +138,7 @@ public:
             std::unique_lock<std::shared_mutex> lock(lock_dirlistcache);
             if (cache_size >= MAX_CACHE_SIZE_LIMIT)
             {
-                AZLogWarn("Exceeding cache max size. No more entries will be added to the cache! cuurent size: {}", cache_size); 
+                AZLogWarn("Exceeding cache max size. No more entries will be added to the cache! cuurent size: {}", cache_size);
                 return false;
             }
 
@@ -172,7 +176,7 @@ public:
 
     void set_eof()
     {
-         AZLogInfo("set eof called");
+        AZLogInfo("set eof called");
         eof = true;
     }
 
@@ -195,9 +199,29 @@ public:
         return false;
     }
 
-    ~directory_list_cache()
+    void clear()
     {
-        AZLogInfo(" ~directory_list_cache() called");
+        AZLogInfo("clear called");
+        // This cache has now become invalid. clean it up.
+        std::unique_lock<std::shared_mutex> lock(lock_dirlistcache);
+
+        eof = false;
+        cache_size = 0;
+        last_mtimecheck = std::time(nullptr);
+        ::memset(&cookie_verifier, 0, sizeof(cookie_verifier));
+
+  //      create_time(std::time(nullptr)),
+        for (auto it = dir_entries.begin(); it != dir_entries.end(); ++it)
+        {
+            free(it->second);
+        }
+
+        dir_entries.clear();
+    }
+
+    ~readdirectory_cache()
+    {
+        AZLogInfo(" ~readdirectory_cache() called");
         // This cache has now become invalid. clean it up.
         std::unique_lock<std::shared_mutex> lock(lock_dirlistcache);
 
@@ -208,317 +232,32 @@ public:
 
         dir_entries.clear();
     }
-};
 
-static bool are_mtimes_equal(const struct stat* attr1, const struct stat* attr2)
-{
+// Helper methods.
+    static bool are_mtimes_equal(const struct stat* attr1, const struct stat* attr2)
+    {
 // #TODO : Added only for testing. Remove this!!
-return true;
+        return true;
         static int i =0;
         if (++i % 5 == 0)
             return true;
-         else
+        else
             return false;
 
-    if (attr1 == nullptr || attr2 == nullptr) {
-        //        std::cerr << "One of the attributes is null." << std::endl;
-        return false;
+        if (attr1 == nullptr || attr2 == nullptr) {
+            //        std::cerr << "One of the attributes is null." << std::endl;
+            return false;
+        }
+        return (attr1->st_mtim.tv_sec == attr2->st_mtim.tv_sec) &&
+               (attr1->st_mtim.tv_nsec == attr2->st_mtim.tv_nsec);
     }
-    return (attr1->st_mtim.tv_sec == attr2->st_mtim.tv_sec) &&
-           (attr1->st_mtim.tv_nsec == attr2->st_mtim.tv_nsec);
-}
-
-/*
- * This is the readdir map which contains a map of the readdir listing
- * corresponding to a inode.
- */
-struct readdir_cache
-{
-private:
-    std::map<fuse_ino_t, std::shared_ptr<directory_list_cache>> m_readdirmap;
-
-    std::shared_mutex m_lockreaddirmap;
-
-    // nfs client instance to which this cache belongs.
-    const nfs_client* nfsclient;
-
-    readdir_cache(const nfs_client* nfsclient_):
-        nfsclient(nfsclient_)
-    {}
-
-public:
-    static struct readdir_cache* get_instance(const nfs_client* nfsclient)
-    {
-        static readdir_cache rcache(nfsclient);
-        return &rcache;
-    }
-
-    bool make_getattr_call(fuse_ino_t inode, struct stat& attr)
+    static bool make_getattr_call(fuse_ino_t inode, struct stat& attr)
     {
         // Make a sync call to fetch the attributes.
 
         // TODO: Populate this function.
         return true;
     }
-
-    // Purge the entry corresponding to ino
-    void purge(fuse_ino_t inode)
-    {
-        // Take exclusive lock to purge the cache.
-        std::unique_lock<std::shared_mutex> lock(m_lockreaddirmap);
-        const auto it = m_readdirmap.find(inode);
-        if (it !=  m_readdirmap.end())
-        {
-            /*
-             * Note: If someone is already holding a ref to this shared pointer, they will
-             * continue to use it till it goes out of scope.
-             */
-            m_readdirmap.erase(it);
-        }
-    }
-
-    // Checks if the cache entry should be purged. Returns true if purging is done.
-    bool purge_cache_if_required(fuse_ino_t inode)
-    {
-        // TODO: Just pass inode and get the shared ptr from find.
-        std::shared_ptr<directory_list_cache> dircache_handle;
-        {
-            // Taske sahred lock to see if the entry already exists.
-            std::shared_lock<std::shared_mutex> lock(m_lockreaddirmap);
-            const auto it = m_readdirmap.find(inode);
-            if (it !=  m_readdirmap.end())
-            {
-                // Return the entry if it exists in the map.
-                dircache_handle = it->second;
-            }
-            else
-            {
-                // No entry in the cache, no point in purgin.
-                return false;
-            }
-        }
-
-        struct directory_entry* dirent = nullptr;
-        bool success = false;
-        struct stat attr;
-
-        /*
-         * For now the only prune condition check is the directory mtime.
-         * This function can later be extended to add more conditions.
-         */
-        bool should_update_mtime = false;
-        {
-            // Take a shared lock to see if the last_mtime_check is greater than 30 secs.
-            //std::shared_lock<std::shared_mutex> lock(dircache_handle->get_lock());
-
-            bool found = dircache_handle->get_entry_at(1 /* cookie*/, &dirent); // cookie 1 represent '.', hence this gets us cached dir mtime.
-            if (!found)
-            {
-                /*
-                 * cookie = 0 refers to the current directory '.'.
-                 * This entry should never be purged from the cache, else we will not know the cached
-                 * directory mtime.
-                 * If we encounter such a state, just purge the complete cache and proceed.
-                 */
-                goto purge_cache;
-            }
-
-            const std::time_t now = std::time(nullptr);
-            const std::time_t last_mtimecheck = dircache_handle->get_lastmtime();
-            assert (now >= last_mtimecheck);
-            if (std::difftime(now, last_mtimecheck) > 30) /*sec. TODO: Add #define for this */
-            {
-                should_update_mtime = true;
-            }
-            else
-            {
-                // No need to do any mtime check, just return.
-                return false;
-            }
-        }
-
-        if (should_update_mtime)
-        {
-            success = make_getattr_call(inode, attr);
-            // Issue a getattr call to the server to fetch the directory mtime.
-        }
-
-        if (success)
-        {
-            // std::shared_lock<std::shared_mutex> lock(dircache_handle->get_lock());
-            if (!are_mtimes_equal(&dirent->attributes, &attr))
-            {
-                /*
-                * Purge the cache since the directory mtime has changed/
-                * THis indicates that the directory has changed.
-                */
-                goto purge_cache;
-            }
-
-            // Update the mtime.
-            dircache_handle->set_mtime();
-            return false;
-        }
-        else
-        {
-            // TODO: What should we do if getattr call fails?
-            return false;
-        }
-
-purge_cache:
-        purge(inode);
-        return true;
-    }
-
-
-    /*
-     * This method gets a directory handle to the directory_list_cache into which the
-     * directory entries are inserted.
-     * If the handle exists, it returns the existing handle, else it creates a new handle
-     * and returns this newly created handle.
-     * THe caller owning this handle should take appropriate lock before accessing the
-     * shared pointer members.
-     */
-    std::shared_ptr<directory_list_cache> get(fuse_ino_t inode)
-    {
-        // Check if the cache should be purged.
-        purge_cache_if_required(inode);
-
-        {
-            // Taske sahred lock to see if the entry already exists.
-            std::shared_lock<std::shared_mutex> lock(m_lockreaddirmap);
-            const auto it = m_readdirmap.find(inode);
-            if (it !=  m_readdirmap.end())
-            {
-                // Return the entry if it exists in the map.
-                return it->second;
-            }
-        }
-
-        /*
-         * If we reach here, it means the entry corresponding to the inode does not exist.
-         * We will create a new entry in the map and then return the directory_list_cache poitner.
-         */
-
-        std::shared_ptr<directory_list_cache> dirlistcache_handle =
-            std::make_shared<directory_list_cache>(inode);
-
-        // Take an exclusive lock to insert the entry to the map.
-        std::unique_lock<std::shared_mutex> lock(m_lockreaddirmap);
-        auto it = m_readdirmap.insert({inode, dirlistcache_handle});
-
-        /*
-         * There is the chance that the above insert can fail if another thread inserts
-         * the entry by the time we upgrade from shared_lock to exclusive_lock on the map.
-         */
-        if (!it.second)
-        {
-            const auto iter = m_readdirmap.find(inode);
-            assert(iter != m_readdirmap.end());
-            return iter->second;
-        }
-
-        return dirlistcache_handle;
-    }
-
-#if 0
-    bool add(fuse_ino_t inode, std::shared_ptr<directory_list_cache> dir_cache)
-    {
-        // Take exclusive lock to add the entry to the cache.
-        std::unique_lock<std::shared_mutex> lock(m_lockreaddirmap);
-//         std::shared_ptr<directory_list_cache> dir_cache_sp(dir_cache);
-        const auto& it = m_readdirmap.insert({inode, dir_cache});
-        return it.second;
-    }
-#endif
-    /*
-     * This function lists directory entries corresponding to the inode.
-     * It looks into the cache to list entries starting from cookie \p cookie_ and
-     * fills the entry into \p results upto max size \pmax_size.
-     * Note: This will only fetch the entries from the cache and does not do a backend call.
-     */
-    void lookup(
-        fuse_ino_t inode /* dir inode for which readdir call is requested */,
-        cookie3 cookie_ /* offset in the directory from which the directory should be listed*/,
-        size_t max_size /* maximum size of entries to be returned*/,
-        std::vector<directory_entry* >& results /* dir entries listed*/,
-        //size_t& result_size /* size of the directory entries being returned*/,
-        bool& eof,
-        bool skip_attr_size = false)
-    {
-        // Check if the cache should be purged.
-        purge_cache_if_required(inode);
-
-        std::shared_ptr<directory_list_cache> dir_cache_handle;
-        {
-            // Take a shared lock on the map.
-            std::shared_lock<std::shared_mutex> lock(m_lockreaddirmap);
-
-            auto it = m_readdirmap.find(inode);
-            if (it != m_readdirmap.end())
-            {
-                dir_cache_handle = it->second;
-            }
-            else
-            {
-                // There is no entry corresponding to this inode in the cache.
-                return;
-                //return false;
-            }
-
-            /*
-             * Note: The shared-lock on the m_readdirmap is released here, as we already have obtained the
-             *       shared_ptr on the directory_list_cache entry. So we basically have a shared pointer to access
-             *       the directory entries and we do not have to block access to other directory listing.
-             */
-        }
-
-        int num_of_entries_found_in_cache = 0;
-
-        size_t rem_size = max_size;
-        //bool dir_present_in_cache = false;
-        while (rem_size > 0)
-        {
-            struct directory_entry* entry;
-            bool found = dir_cache_handle->lookup(cookie_, &entry);
-            if (found)
-            {
-         //       dir_present_in_cache = true;
-                const size_t curr_entry_size = entry->get_size(skip_attr_size);
-                if (rem_size >= curr_entry_size)
-                {
-                    num_of_entries_found_in_cache++;
-                    //result_size += curr_entry_size;
-                    results.push_back(entry);
-                }
-                else
-                {
-                    // We have populated the maximum entries requested, hence break.
-                    break;
-                }
-                rem_size -= curr_entry_size;
-                cookie_++;
-            }
-            else
-            {
-                AZLogDebug("Traversed map: Num of entries returned from cache {}", num_of_entries_found_in_cache);
-
-                /*
-                 * If we don't find the current cookie, then we will not find the next
-                 * ones as well since they are stored sequentially.
-                 */
-                return;
-                //return false;
-            }
-        }
-
-        eof = dir_cache_handle->get_eof();
-        AZLogDebug("Buffer exhaust: Num of entries returned from cache {}", num_of_entries_found_in_cache);
-        /*
-         * NOTE: We will not populate the cookie verifier here nor access it since
-         * that will be done only at the time the readdir call is made to the backend.
-         */
-        //return dir_present_in_cache;
-    }
 };
-#endif /* __READDIR_RPC_TASK__ */
+#endif /* __READDIR_RPC_TASK___ */
+

--- a/nfs/inc/rpc_readdir.h
+++ b/nfs/inc/rpc_readdir.h
@@ -222,28 +222,12 @@ public:
     // Various helper methods added below.
     static bool are_mtimes_equal(const struct stat* attr1, const struct stat* attr2)
     {
-// #TODO : Added only for testing. Remove this!!
-        return true;
-        static int i =0;
-        if (++i % 5 == 0)
-            return true;
-        else
-            return false;
-
         if (attr1 == nullptr || attr2 == nullptr) {
             //        std::cerr << "One of the attributes is null." << std::endl;
             return false;
         }
         return (attr1->st_mtim.tv_sec == attr2->st_mtim.tv_sec) &&
                (attr1->st_mtim.tv_nsec == attr2->st_mtim.tv_nsec);
-    }
-    
-    static bool make_getattr_call(fuse_ino_t inode, struct stat& attr)
-    {
-        // Make a sync call to fetch the attributes.
-
-        // TODO: Populate this function.
-        return true;
     }
 };
 #endif /* __READDIR_RPC_TASK___ */

--- a/nfs/inc/rpc_task.h
+++ b/nfs/inc/rpc_task.h
@@ -277,6 +277,7 @@ public:
 
     void set_cookieverf(const cookieverf3* cokieverf)
     {
+    if (cokieverf != nullptr)
         ::memcpy(&cookieverf, cokieverf, sizeof(cookieverf));
     }
 
@@ -356,6 +357,8 @@ public:
 
     void set_cookieverf(const cookieverf3* cokieverf)
     {
+    if (cokieverf != nullptr)
+
         ::memcpy(&cookieverf, cokieverf, sizeof(cookieverf));
     }
 

--- a/nfs/inc/rpc_task.h
+++ b/nfs/inc/rpc_task.h
@@ -248,6 +248,164 @@ private:
  * The RPC task tracks the progress of the RPC request sent to the server and
  * remains valid till the RPC request completes.
  */
+struct readdir_rpc_task
+{
+public:
+    void set_size(size_t sz)
+    {
+        size = sz;
+    }
+
+    void set_offset(off_t off)
+    {
+        offset = off;
+    }
+
+    void set_inode(fuse_ino_t ino)
+    {
+        inode = ino;
+    }
+
+    void set_fuse_file(fuse_file_info* fileinfo)
+    {
+        // The fuse can pass this as nullptr.
+        if (fileinfo == nullptr)
+            return;
+        ::memcpy(&file, fileinfo, sizeof(file));
+        file_ptr = &file;
+    }
+
+    void set_cookieverf(const cookieverf3* cokieverf)
+    {
+        ::memcpy(&cookieverf, cokieverf, sizeof(cookieverf));
+    }
+
+    void set_cookie(cookie3 cokie)
+    {
+        cookie = cokie;
+    }
+
+    fuse_ino_t get_inode() const
+    {
+        return inode;
+    }
+
+    cookie3 get_cookie() const
+    {
+        return cookie;
+    }
+
+    const cookieverf3* get_cookieverf() const
+    {
+        return &cookieverf;
+    }
+
+    off_t get_offset() const
+    {
+        return offset;
+    }
+
+    size_t get_size() const
+    {
+        return size;
+    }
+
+private:
+    // Inode of the directory.
+    fuse_ino_t inode;
+
+    size_t size;
+
+    off_t offset;
+
+    cookie3 cookie;
+
+    cookieverf3 cookieverf;
+
+// File info passed by the fuse layer.
+    fuse_file_info file;
+    fuse_file_info* file_ptr;
+};
+
+struct readdirplus_rpc_task
+{
+public:
+    void set_size(size_t sz)
+    {
+        size = sz;
+    }
+
+    void set_offset(off_t off)
+    {
+        offset = off;
+    }
+
+    void set_inode(fuse_ino_t ino)
+    {
+        inode = ino;
+    }
+
+    void set_fuse_file(fuse_file_info* fileinfo)
+    {
+        // The fuse can pass this as nullptr.
+        if (fileinfo == nullptr)
+            return;
+        ::memcpy(&file, fileinfo, sizeof(file));
+        file_ptr = &file;
+    }
+
+    void set_cookieverf(const cookieverf3* cokieverf)
+    {
+        ::memcpy(&cookieverf, cokieverf, sizeof(cookieverf));
+    }
+
+    void set_cookie(cookie3 cokie)
+    {
+        cookie = cokie;
+    }
+
+    fuse_ino_t get_inode() const
+    {
+        return inode;
+    }
+
+    off_t get_offset() const
+    {
+        return offset;
+    }
+
+    cookie3 get_cookie() const
+    {
+        return cookie;
+    }
+
+    const cookieverf3* get_cookieverf() const
+    {
+        return &cookieverf;
+    }
+
+    size_t get_size() const
+    {
+        return size;
+    }
+
+private:
+    // Inode of the directory.
+    fuse_ino_t inode;
+
+    size_t size;
+
+    off_t offset;
+
+    cookie3 cookie;
+
+    cookieverf3 cookieverf;
+
+    // File info passed by the fuse layer.
+    fuse_file_info file;
+    fuse_file_info* file_ptr;
+};
+
 struct rpc_task
 {
     /*
@@ -290,6 +448,8 @@ public:
         struct setatt_rpc_task setattr_task;
         struct create_file_rpc_task create_task;
         struct mkdir_rpc_task mkdir_task;
+        struct readdir_rpc_task readdir_task;
+        struct readdirplus_rpc_task readdirplus_task;
     } rpc_api;
 
     // TODO: Add valid flag here for APIs?
@@ -338,6 +498,37 @@ public:
                     mode_t mode);
     void run_mkdir();
 
+    // TODO: Change these names
+    // This function is responsible for setting up the members of readdir_task.
+    void set_readdir(struct nfs_client* clt,
+                     fuse_req* request,
+                     fuse_ino_t inode,
+                     size_t size,
+                     off_t offset,
+                     struct fuse_file_info* file);
+
+    // This function is responsible for issuing the readdir call to the server.
+    // readdir_task structure should be populated before calling this function
+    // by calling set_readdir().
+    void run_readdir();
+
+    // This function is responsible for setting up the members of readdirplus_task.
+    void set_readdirplus(struct nfs_client* clt,
+                         fuse_req* request,
+                         fuse_ino_t inode,
+                         size_t size,
+                         off_t offset,
+                         struct fuse_file_info* file);
+
+    // This function is responsible for issuing the readdirplus call to the server.
+    // readdirplus_task structure should be populated before calling this function
+    // by calling set_readdirplus().
+    void run_readdirplus();
+
+    void set_client(struct nfs_client* clt)
+    {
+        client = clt;
+    }
 
     void set_fuse_req(fuse_req *request)
     {

--- a/nfs/inc/rpc_task.h
+++ b/nfs/inc/rpc_task.h
@@ -499,7 +499,7 @@ public:
         free_task_index.pop();
 
         // Must be a valid index.
-        assert(free_index > 0 && free_index < MAX_OUTSTANDING_RPC_TASKS);
+        assert(free_index >= 0 && free_index < MAX_OUTSTANDING_RPC_TASKS);
 
         return free_index;
     }
@@ -507,7 +507,7 @@ public:
     void release_free_index(int index)
     {
         // Must be a valid index.
-        assert(index > 0 && index < MAX_OUTSTANDING_RPC_TASKS);
+        assert(index >= 0 && index < MAX_OUTSTANDING_RPC_TASKS);
 
         {
             std::unique_lock<std::shared_mutex> lock(task_index_lock);

--- a/nfs/inc/rpc_task.h
+++ b/nfs/inc/rpc_task.h
@@ -276,40 +276,9 @@ public:
         file_ptr = &file;
     }
 
-    void set_cookieverf(const cookieverf3* cokieverf)
-    {
-    if (cokieverf != nullptr)
-        ::memcpy(&cookieverf, cokieverf, sizeof(cookieverf));
-    }
-
-    void set_cookie(cookie3 cokie)
-    {
-        cookie = cokie;
-    }
-    
-    void set_buffer(char* buf)
-    {
-        buffer = buf;
-    }
-
-    void set_buffer_size(size_t size)
-    {
-        buffer_size = size;
-    }
-
     fuse_ino_t get_inode() const
     {
         return inode;
-    }
-
-    cookie3 get_cookie() const
-    {
-        return cookie;
-    }
-
-    const cookieverf3* get_cookieverf() const
-    {
-        return &cookieverf;
     }
 
     off_t get_offset() const
@@ -321,11 +290,6 @@ public:
     {
         return size;
     }
-    
-   // std::vector<directory_entry*> m_results;
-   // size_t result_size;
-
-    //void send_response();
 
 private:
     // Inode of the directory.
@@ -336,17 +300,9 @@ private:
 
     off_t offset;
 
-    cookie3 cookie;
-
-    cookieverf3 cookieverf;
-
-// File info passed by the fuse layer.
+    // File info passed by the fuse layer.
     fuse_file_info file;
     fuse_file_info* file_ptr;
-
-    // The buffer should be set to null and buffer_size should be set to 0 in the setup.
-    char* buffer;
-    size_t buffer_size;
 };
 
 struct readdirplus_rpc_task
@@ -376,28 +332,6 @@ public:
         file_ptr = &file;
     }
 
-    void set_cookieverf(const cookieverf3* cokieverf)
-    {
-    if (cokieverf != nullptr)
-
-        ::memcpy(&cookieverf, cokieverf, sizeof(cookieverf));
-    }
-
-    void set_cookie(cookie3 cokie)
-    {
-        cookie = cokie;
-    }
-
-    void set_buffer(char* buf)
-    {
-        buffer = buf;
-    }
-
-    void set_buffer_size(size_t size)
-    {
-        buffer_size = size;
-    }
-
     fuse_ino_t get_inode() const
     {
         return inode;
@@ -408,24 +342,10 @@ public:
         return offset;
     }
 
-    cookie3 get_cookie() const
-    {
-        return cookie;
-    }
-
-    const cookieverf3* get_cookieverf() const
-    {
-        return &cookieverf;
-    }
-
     size_t get_size() const
     {
         return size;
     }
-
-    // TODO: Have accesor functions.
-    //std::vector<directory_entry> m_results;
-    //size_t result_size;
 
 private:
     // Inode of the directory.
@@ -436,17 +356,9 @@ private:
 
     off_t offset;
 
-    cookie3 cookie;
-
-    cookieverf3 cookieverf;
-
     // File info passed by the fuse layer.
     fuse_file_info file;
     fuse_file_info* file_ptr;
-
-    // The buffer should be set to null and buffer_size should be set to 0 in the setup.
-    char* buffer;
-    size_t buffer_size;
 };
 
 struct rpc_task
@@ -468,10 +380,6 @@ struct rpc_task
 
     // This is the index of the object in the rpc_task_list vector.
     const int index;
-
-    // TODO: See if we can move to readdir_task.
-    //std::vector<directory_entry*> m_readdirentries;
-    //size_t readdir_result_size;
 
 protected:
     /*
@@ -545,14 +453,12 @@ public:
                     mode_t mode);
     void run_mkdir();
 
-    // TODO: Change these names
     // This function is responsible for setting up the members of readdir_task.
-    void set_readdir(struct nfs_client* clt,
-                     fuse_req* request,
+    void init_readdir(fuse_req *request,
                      fuse_ino_t inode,
                      size_t size,
                      off_t offset,
-                     struct fuse_file_info* file);
+                     struct fuse_file_info *file);
 
     // This function is responsible for issuing the readdir call to the server.
     // readdir_task structure should be populated before calling this function
@@ -560,22 +466,16 @@ public:
     void run_readdir();
 
     // This function is responsible for setting up the members of readdirplus_task.
-    void set_readdirplus(struct nfs_client* clt,
-                         fuse_req* request,
+    void init_readdirplus(fuse_req *request,
                          fuse_ino_t inode,
                          size_t size,
                          off_t offset,
-                         struct fuse_file_info* file);
+                         struct fuse_file_info *file);
 
     // This function is responsible for issuing the readdirplus call to the server.
     // readdirplus_task structure should be populated before calling this function
     // by calling set_readdirplus().
     void run_readdirplus();
-
-    void set_client(struct nfs_client* clt)
-    {
-        client = clt;
-    }
 
     void set_fuse_req(fuse_req *request)
     {

--- a/nfs/inc/rpc_task.h
+++ b/nfs/inc/rpc_task.h
@@ -7,8 +7,6 @@
 #include <stack>
 #include <shared_mutex>
 #include <vector>
-#include "rpc_readdir.h"
-
 #include "nfs_client.h"
 
 #define MAX_OUTSTANDING_RPC_TASKS 65536
@@ -460,9 +458,6 @@ public:
                      off_t offset,
                      struct fuse_file_info *file);
 
-    // This function is responsible for issuing the readdir call to the server.
-    // readdir_task structure should be populated before calling this function
-    // by calling set_readdir().
     void run_readdir();
 
     // This function is responsible for setting up the members of readdirplus_task.
@@ -472,9 +467,6 @@ public:
                          off_t offset,
                          struct fuse_file_info *file);
 
-    // This function is responsible for issuing the readdirplus call to the server.
-    // readdirplus_task structure should be populated before calling this function
-    // by calling set_readdirplus().
     void run_readdirplus();
 
     void set_fuse_req(fuse_req *request)
@@ -547,7 +539,6 @@ public:
     }
 
     /*
-     *
      * Check RPC completion for success.
      * Returns true if rpc_task succeeded execution at the server, else
      * returns false.
@@ -563,7 +554,6 @@ public:
         return req;
     }
 
-    // TODO: See if this should be moved to other place.
     void send_readdir_response(std::vector<directory_entry*>& readdirentries);
 
     void send_readdirplus_response(std::vector<directory_entry*>& readdirentries);

--- a/nfs/inc/rpc_task.h
+++ b/nfs/inc/rpc_task.h
@@ -470,8 +470,8 @@ struct rpc_task
     const int index;
 
     // TODO: See if we can move to readdir_task.
-    std::vector<directory_entry*> m_readdirentries;
-    size_t readdir_result_size;
+    //std::vector<directory_entry*> m_readdirentries;
+    //size_t readdir_result_size;
 
 protected:
     /*
@@ -664,9 +664,9 @@ public:
     }
 
     // TODO: See if this should be moved to other place.
-    void send_readdir_response();
+    void send_readdir_response(std::vector<directory_entry*>& readdirentries);
 
-    void send_readdirplus_response();
+    void send_readdirplus_response(std::vector<directory_entry*>& readdirentries);
 
     void get_readdir_entries_from_cache();
 

--- a/nfs/inc/rpc_task.h
+++ b/nfs/inc/rpc_task.h
@@ -7,6 +7,7 @@
 #include <stack>
 #include <shared_mutex>
 #include <vector>
+#include "rpc_readdir.h"
 
 #include "nfs_client.h"
 
@@ -285,6 +286,16 @@ public:
     {
         cookie = cokie;
     }
+    
+    void set_buffer(char* buf)
+    {
+        buffer = buf;
+    }
+
+    void set_buffer_size(size_t size)
+    {
+        buffer_size = size;
+    }
 
     fuse_ino_t get_inode() const
     {
@@ -310,11 +321,17 @@ public:
     {
         return size;
     }
+    
+   // std::vector<directory_entry*> m_results;
+   // size_t result_size;
+
+    //void send_response();
 
 private:
     // Inode of the directory.
     fuse_ino_t inode;
 
+    // Maximum size of entries requested by the caller.
     size_t size;
 
     off_t offset;
@@ -326,6 +343,10 @@ private:
 // File info passed by the fuse layer.
     fuse_file_info file;
     fuse_file_info* file_ptr;
+
+    // The buffer should be set to null and buffer_size should be set to 0 in the setup.
+    char* buffer;
+    size_t buffer_size;
 };
 
 struct readdirplus_rpc_task
@@ -367,6 +388,16 @@ public:
         cookie = cokie;
     }
 
+    void set_buffer(char* buf)
+    {
+        buffer = buf;
+    }
+
+    void set_buffer_size(size_t size)
+    {
+        buffer_size = size;
+    }
+
     fuse_ino_t get_inode() const
     {
         return inode;
@@ -392,10 +423,15 @@ public:
         return size;
     }
 
+    // TODO: Have accesor functions.
+    //std::vector<directory_entry> m_results;
+    //size_t result_size;
+
 private:
     // Inode of the directory.
     fuse_ino_t inode;
 
+    // Maximum size of entries requested by the caller.
     size_t size;
 
     off_t offset;
@@ -407,6 +443,10 @@ private:
     // File info passed by the fuse layer.
     fuse_file_info file;
     fuse_file_info* file_ptr;
+
+    // The buffer should be set to null and buffer_size should be set to 0 in the setup.
+    char* buffer;
+    size_t buffer_size;
 };
 
 struct rpc_task
@@ -428,6 +468,10 @@ struct rpc_task
 
     // This is the index of the object in the rpc_task_list vector.
     const int index;
+
+    // TODO: See if we can move to readdir_task.
+    std::vector<directory_entry*> m_readdirentries;
+    size_t readdir_result_size;
 
 protected:
     /*
@@ -618,6 +662,17 @@ public:
     {
         return req;
     }
+
+    // TODO: See if this should be moved to other place.
+    void send_readdir_response();
+
+    void send_readdirplus_response();
+
+    void get_readdir_entries_from_cache();
+
+    void get_readdirplus_entries_from_cache();
+
+    void fetch_readdir_entries_from_server();
 };
 
 class rpc_task_helper

--- a/nfs/src/file_cache.cpp
+++ b/nfs/src/file_cache.cpp
@@ -1,0 +1,1067 @@
+#include "file_cache.h"
+#include "log.h"
+#include <random>
+
+// This enables debug logs and also runs the self tests.
+//#define DEBUG_FILE_CACHE
+
+#ifndef DEBUG_FILE_CACHE
+#undef AZLogInfo
+#undef AZLogDebug
+#define AZLogInfo(fmt, ...)     /* nothing */
+#define AZLogDebug(fmt, ...)    /* nothing */
+#else
+// Debug is not enabled early on when self-tests run, so use Info.
+//#undef AZLogDebug
+//#define AZLogDebug AZLogInfo
+#endif
+
+namespace aznfsc {
+
+std::vector<bytes_chunk> bytes_chunk_cache::scan(uint64_t offset,
+                                                 uint64_t length,
+                                                 scan_action action,
+                                                 uint64_t *extent_left,
+                                                 uint64_t *extent_right)
+{
+    assert(offset < AZNFSC_MAX_FILE_SIZE);
+    assert(length > 0);
+    // Cannot write more than AZNFSC_MAX_CHUNK_SIZE in a single call.
+    assert(length <= AZNFSC_MAX_CHUNK_SIZE);
+    assert((offset + length) <= AZNFSC_MAX_FILE_SIZE);
+    assert((action == scan_action::SCAN_ACTION_GET) ||
+           (action == scan_action::SCAN_ACTION_RELEASE));
+
+    // Range check makes sense only for get().
+    assert((action == scan_action::SCAN_ACTION_GET) ||
+           (extent_left == nullptr && extent_right == nullptr));
+
+    // Doesn't make sense to query just one.
+    assert((extent_left == nullptr) == (extent_right == nullptr));
+
+    // bytes_chunk vector that will be returned to the caller.
+    std::vector<bytes_chunk> chunkvec;
+
+    // offset and length cursor, updated as we add chunks to chunkvec.
+    uint64_t next_offset = offset;
+    uint64_t remaining_length = length;
+
+    // Convenience variable to access the current chunk in the map.
+    bytes_chunk *bc;
+
+    // Temp variables to hold chunk details for newly added chunk.
+    uint64_t chunk_offset, chunk_length;
+    uint8_t *chunk_buffer;
+
+    /*
+     * Temp variables to hold details for releasing a range.
+     * All chunks in the range [begin_delete, end_delete) will be freed as
+     * they fall completely inside the released range.
+     * When we release a range that completely lies within a chunk, then we need
+     * to allocate a new chunk to hold the data after the released range, while
+     * the existing chunk is trimmed to hold the data before the range.
+     * chunk_after is the new chunk thus created.
+     * Used only for SCAN_ACTION_RELEASE.
+     */
+    std::map <uint64_t,
+              struct bytes_chunk>::iterator begin_delete = chunkmap.end();
+    std::map <uint64_t,
+              struct bytes_chunk>::iterator end_delete = chunkmap.end();
+    struct bytes_chunk *chunk_after = nullptr;
+
+    /*
+     * Variables to track the extent this write is part of.
+     * We will udpate these as the left and right edges of the extent are
+     * confirmed. Used only for SCAN_ACTION_GET.
+     * lookback_it is the iterator to the chunk starting which we should
+     * "look back" for the left edge of the extent containing the just written
+     * chunk. We basically scan to the left till we find a gap or we hit the
+     * end.
+     */
+    uint64_t _extent_left = AZNFSC_BAD_OFFSET;
+    uint64_t _extent_right = AZNFSC_BAD_OFFSET;
+    std::map <uint64_t,
+              struct bytes_chunk>::iterator lookback_it = chunkmap.end();
+
+    /*
+     * TODO: See if we can hold shared lock for cases where we don't have to
+     *       update chunkmap.
+     */
+    const std::unique_lock<std::mutex> _lock(lock);
+
+    /*
+     * Find chunk with offset >= next_offset.
+     * We start from the first chunk covering the start of the requested range
+     * and then iterate over the subsequent chunks (allocating missing chunks
+     * along the way) till we cover the entire requested range. Newly allocated
+     * chunks can be identified in the returned chunkvec as they have is_empty
+     * set.
+     */
+    auto it = chunkmap.lower_bound(next_offset);
+
+    if (it == chunkmap.end()) {
+        /*
+         * next_offset is greater than the greatest offset in the chunkmap.
+         * We still have to check the last chunk to see if it has some or all
+         * of the requested range.
+         */
+        if (chunkmap.empty()) {
+            /*
+             * Cache-release is called only after cache-get which would have
+             * allocated the requested range, so we should not find non-existent
+             * chunks in the requested range.
+             */
+            assert(action != scan_action::SCAN_ACTION_RELEASE);
+
+            /*
+             * Only chunk being added, so left and right edge of that are also
+             * the extent's left and right edge.
+             */
+            _extent_left = next_offset;
+            _extent_right = next_offset + remaining_length;
+
+            AZLogDebug("(first chunk) _extent_left: {} _extent_right: {}",
+                       _extent_left, _extent_right);
+
+            goto allocate_only_chunk;
+        } else {
+            // Iterator to the last chunk.
+            it = std::prev(it);
+            bc = &(it->second);
+
+            if ((bc->offset + bc->length) <= next_offset) {
+                /*
+                 * Requested range lies after the end of last chunk, we will need
+                 * to allocate a new chunk and this will be the only chunk needed
+                 * to cover the requested range.
+                 */
+                assert(action != scan_action::SCAN_ACTION_RELEASE);
+
+                /*
+                 * If this new chunk starts right after the last chunk, then
+                 * we don't know the actual value of _extent_left unless we
+                 * scan left and check. In that case we set lookback_it to 'it'
+                 * so that we can later "look back" and find the left edge.
+                 * If it doesn't start right after, then next_offset becomes
+                 * _extent_left.
+                 */
+                if ((bc->offset + bc->length) < next_offset) {
+                    _extent_left = next_offset;
+                    AZLogDebug("_extent_left: {}", _extent_left);
+                } else {
+                    AZLogDebug("lookback_it: [{},{})",
+                               bc->offset, bc->offset + bc->length);
+                    lookback_it = it;
+                }
+
+                _extent_right = next_offset + remaining_length;
+                AZLogDebug("_extent_right: {}", _extent_right);
+
+                goto allocate_only_chunk;
+            } else {
+                /*
+                 * Part or whole of requested range lies in the last chunk.
+                 * The following for loop will correctly handle this.
+                 * We don't know the left most edge until we "look back" from
+                 * this chunk. Right edge is the right edge of the last chunk
+                 * unless the current chunk goes past that, in which case that
+                 * becomes the right edge. We don't set it here.
+                 */
+                AZLogDebug("lookback_it: [{},{})",
+                           bc->offset, bc->offset + bc->length);
+                lookback_it = it;
+            }
+        }
+    } else {
+        /*
+         * There's at least one chunk having offset greater than the requested
+         * chunk's offset (next_offset).
+         *
+         * it->first >= next_offset, we have two cases:
+         * 1. (it.first == next_offset) => desired data starts from this chunk.
+         * 2. (it.first > next_offset)  => desired data starts before this chunk.
+         *                                 It may start within the prev chunk,
+         *                                 or this chunk may start in the gap
+         *                                 between the prev chunk and this chunk,
+         *                                 in that case we need to create a new
+         *                                 chunk before this chunk.
+         */
+        assert(it->first == it->second.offset);
+        assert(it->first >= next_offset);
+
+        if (it->first == next_offset) {
+            bc = &(it->second);
+            /*
+             * Requested range starts from this chunk.
+             * The following for loop will correctly handle this.
+             * Need to "look back" to find the left edge and look forward to
+             * find the right edge.
+             */
+            AZLogDebug("lookback_it: [{},{})",
+                       bc->offset, bc->offset + bc->length);
+            lookback_it = it;
+        } else {
+            /*
+             * Requested range starts before this chunk.
+             */
+            assert(it->first > next_offset);
+
+            if (it == chunkmap.begin()) {
+                /*
+                 * If this is the first chunk then part or whole of the
+                 * requested range lies before this chunk and we need to
+                 * create a new chunk for that.
+                 */
+                assert(action != scan_action::SCAN_ACTION_RELEASE);
+
+                bc = &(it->second);
+                assert(bc->offset > next_offset);
+
+                // Newly created chunk's offset and length.
+                chunk_offset = next_offset;
+                chunk_length = std::min(bc->offset - next_offset,
+                                        remaining_length);
+
+                remaining_length -= chunk_length;
+                next_offset += chunk_length;
+
+                /*
+                 * This is the first chunk, so its offset is the left edge.
+                 * We mark the right edge tentatively, it'll be confirmed after
+                 * we look forward.
+                 */
+                _extent_left = chunk_offset;
+                _extent_right = chunk_offset + chunk_length;
+
+                AZLogDebug("_extent_left: {}", _extent_left);
+                AZLogDebug("(tentative) _extent_right: {}", _extent_right);
+
+                chunkvec.emplace_back(chunk_offset, chunk_length);
+                AZLogDebug("(new chunk) [{},{})",
+                           chunk_offset, chunk_offset + chunk_length);
+            } else {
+                /*
+                 * Requested range starts before this chunk and we have a
+                 * chunk before this chunk.
+                 */
+
+                // This chunk (we need it later).
+                auto itn = it;
+                bytes_chunk *bcn = &(itn->second);
+                assert(bcn->offset > next_offset);
+
+                // Prev chunk.
+                it = std::prev(it);
+                bc = &(it->second);
+
+                if ((bc->offset + bc->length) <= next_offset) {
+                    /*
+                     * Prev chunk ends before the 1st byte from the requested
+                     * range. This means we need to allocate a chunk after the
+                     * prev chunk. The new chunk size will be from next_offset
+                     * till the start offset of the next chunk (bcn) or
+                     * remaining_length whichever is smaller.
+                     */
+                    assert(action != scan_action::SCAN_ACTION_RELEASE);
+
+                    chunk_offset = next_offset;
+                    chunk_length = std::min(bcn->offset - next_offset,
+                                            remaining_length);
+
+                    remaining_length -= chunk_length;
+                    next_offset += chunk_length;
+
+                    /*
+                     * If this new chunk starts right after the prev chunk, then
+                     * we don't know the actual value of _extent_left unless we
+                     * scan left and check. In that case we set lookback_it to
+                     * the prev chunk, so that we can later "look back" and find
+                     * the left edge.
+                     * If it doesn't start right after, then chunk_offset becomes
+                     * _extent_left.
+                     */
+                    if ((bc->offset + bc->length) < next_offset) {
+                        /*
+                         * New chunk does not touch the prev chunk, so the new
+                         * chunk offset is the _extent_left.
+                         */
+                        _extent_left = chunk_offset;
+                        AZLogDebug("_extent_left: {}", _extent_left);
+                    } else {
+                        /*
+                         * Else, new chunk touches the prev chunk, so we need
+                         * to "look back" for finding the left edge.
+                         */
+                        AZLogDebug("lookback_it: [{},{})",
+                                   bc->offset, bc->offset + bc->length);
+                        lookback_it = it;
+                    }
+                    _extent_right = chunk_offset + chunk_length;
+                    AZLogDebug("(tentative) _extent_right: {}", _extent_right);
+
+                    // Search for more chunks should start from the next chunk.
+                    it = itn;
+
+                    chunkvec.emplace_back(chunk_offset, chunk_length);
+                    AZLogDebug("(new chunk) [{},{})",
+                               chunk_offset, chunk_offset + chunk_length);
+                } else {
+                    /*
+                     * Prev chunk contains some bytes from initial part of the
+                     * requested range. The following for loop will correctly
+                     * handle this.
+                     */
+                    AZLogDebug("lookback_it: [{},{})",
+                               bc->offset, bc->offset + bc->length);
+                    lookback_it = it;
+                }
+            }
+        }
+    }
+
+    /*
+     * Either we should know the left edge or we should have set the lookback_it
+     * to the chunk from where we start "looking back".
+     */
+    assert((_extent_left == AZNFSC_BAD_OFFSET) ==
+           (lookback_it != chunkmap.end()));
+
+    /*
+     * Now sequentially go over the remaining chunks till we cover the entire
+     * requested range. If some chunk doesn't exist, it'll be allocated.
+     */
+    for (; remaining_length != 0 && it != chunkmap.end(); ) {
+        bc = &(it->second);
+
+        /*
+         * next_offset must lie before the end of current chunk, else we should
+         * not be inside the for loop.
+         */
+        assert(next_offset < (bc->offset + bc->length));
+
+        chunk_offset = next_offset;
+
+        if (next_offset == bc->offset) {
+            chunk_length = std::min(bc->length, remaining_length);
+            chunk_buffer = bc->buffer;
+
+            if (action == scan_action::SCAN_ACTION_GET) {
+                chunkvec.emplace_back(chunk_offset, chunk_length,
+                                      chunk_buffer, bc->alloc_buffer);
+                AZLogDebug("(existing chunk) [{},{}) b:{} a:{}",
+                           chunk_offset, chunk_offset + chunk_length,
+                           fmt::ptr(chunk_buffer),
+                           fmt::ptr(bc->alloc_buffer.get()));
+            } else {
+                assert (action == scan_action::SCAN_ACTION_RELEASE);
+                if (chunk_length == bc->length) {
+                    AZLogDebug("(releasing chunk) [{},{}) b:{} a:{}",
+                               chunk_offset, chunk_offset + chunk_length,
+                               fmt::ptr(chunk_buffer),
+                               fmt::ptr(bc->alloc_buffer.get()));
+                    /*
+                     * Queue the chunk for deletion, since the entire chunk is
+                     * released.
+                     */
+                    if (begin_delete == chunkmap.end()) {
+                        begin_delete = it;
+                    }
+                    /*
+                     * Keep updating end_delete with every full chunk
+                     * processed, that way in the end once we are done we will
+                     * have end_delete correctly point to one past the last
+                     * to-be-deleted chunk.
+                     */
+                    end_delete = std::next(it);
+                } else {
+                    assert(chunk_length == remaining_length);
+                    /*
+                     * Else trim the chunk (from the left).
+                     */
+                    AZLogDebug("(trimming chunk from left) [{},{}) -> [{},{})",
+                               bc->offset, bc->offset + bc->length,
+                               bc->offset + chunk_length,
+                               bc->offset + bc->length);
+
+                    bc->offset += chunk_length;
+                    bc->buffer += chunk_length;
+                    bc->length -= chunk_length;
+
+                    /*
+                     * Since the key (offset) for this chunk changed, we need
+                     * to remove and re-insert into the map (with the updated
+                     * key/offset). For the buffer, it shall refer to the same
+                     * buffer (albeit different offset) that the original chunk
+                     * was using.
+                     * Add the new chunk first before deleting the old chunk,
+                     * else bc->alloc_buffer may get freed.
+                     *
+                     * This can only happen for the last chunk in the range and
+                     * hence it's ok to update the chunkmap. We should exit the
+                     * for loop here.
+                     */
+                    auto p = chunkmap.try_emplace(bc->offset, bc->offset,
+                                                  bc->length, bc->buffer,
+                                                  bc->alloc_buffer);
+                    assert(p.second);
+                    /*
+                     * Now that the older chunk is going and is being replaced
+                     * by this chunk, if end_delete was pointing at the old
+                     * chunk, change it to point to this new chunk. Note that
+                     * the new chunk will be the next in line and hence we
+                     * can safely replace end_delete with this.
+                     */
+                    if (it == end_delete) {
+                        end_delete = p.first;
+                    }
+
+                    chunkmap.erase(it);
+                    goto done;
+                }
+            }
+
+            // This chunk is fully consumed, move to the next chunk.
+            ++it;
+        } else if (next_offset < bc->offset) {
+            assert(action != scan_action::SCAN_ACTION_RELEASE);
+            chunk_length = std::min(bc->offset - next_offset,
+                                    remaining_length);
+
+            chunkvec.emplace_back(chunk_offset, chunk_length);
+            AZLogDebug("(new chunk) [{},{})",
+                       chunk_offset, chunk_offset+chunk_length);
+
+            /*
+             * In the next iteration we need to look at the current chunk, so
+             * don't increment the iterator.
+             */
+        } else /* (next_offset > bc->offset) */ {
+            chunk_length = std::min(bc->offset + bc->length - next_offset,
+                                    remaining_length);
+            chunk_buffer = bc->buffer + (next_offset - bc->offset);
+
+            if (action == scan_action::SCAN_ACTION_GET) {
+                chunkvec.emplace_back(chunk_offset, chunk_length,
+                                      chunk_buffer, bc->alloc_buffer);
+                AZLogDebug("(existing chunk) [{},{}) b:{} a:{}",
+                           chunk_offset, chunk_offset + chunk_length,
+                           fmt::ptr(chunk_buffer),
+                           fmt::ptr(bc->alloc_buffer.get()));
+            } else {
+                assert(action == scan_action::SCAN_ACTION_RELEASE);
+                if (chunk_length == remaining_length) {
+                    /*
+                     * Part of the chunk is released in the middle.
+                     * We need to trim the original chunk to contain data before
+                     * the released data and create a new chunk to hold the data
+                     * after the released data.
+                     */
+                    const uint64_t chunk_after_offset =
+                        next_offset + chunk_length;
+                    const uint64_t chunk_after_length =
+                        bc->offset + bc->length - next_offset - chunk_length;
+
+                    if (chunk_after_length > 0) {
+                        assert(chunk_after == nullptr);
+                        chunk_after = new bytes_chunk(chunk_after_offset,
+                                                      chunk_after_length);
+
+                        AZLogDebug("(chunk after) [{},{})",
+                                   chunk_after_offset,
+                                   chunk_after_offset + chunk_after_length);
+                    }
+
+                    AZLogDebug("(trimming chunk from right) [{},{}) -> [{},{})",
+                            bc->offset, bc->offset + bc->length,
+                            bc->offset, next_offset);
+                    bc->length = next_offset - bc->offset;
+                    assert((int64_t) bc->length > 0);
+                } else {
+                    assert(chunk_length ==
+                           (bc->offset + bc->length - next_offset));
+                    assert(chunk_length < remaining_length);
+
+                    /*
+                     * Entire chunk after next_offset is released, trim the
+                     * chunk.
+                     */
+                    AZLogDebug("(trimming chunk from right) [{},{}) -> [{},{})",
+                               bc->offset, bc->offset + bc->length,
+                               bc->offset, next_offset);
+
+                    bc->length = next_offset - bc->offset;
+                    assert((int64_t) bc->length > 0);
+                }
+            }
+
+            // This chunk is fully consumed, move to the next chunk.
+            ++it;
+        }
+
+done:
+        remaining_length -= chunk_length;
+        assert((int64_t) remaining_length >= 0);
+        next_offset += chunk_length;
+
+        /*
+         * Once this for loop exits, the search for _extent_right continues
+         * with 'it', so we must make sure that 'it' points to the next chunk
+         * that we want to check. Note that we search for _extent_right only
+         * for SCAN_ACTION_GET.
+         */
+        _extent_right = bc->offset + bc->length;
+        AZLogDebug("_extent_right: {}", _extent_right);
+    }
+
+    /*
+     * Allocate the only or the last chunk beyond the highest chunk we have
+     * in our cache.
+     */
+allocate_only_chunk:
+    if (remaining_length != 0) {
+        /*
+         * Other than when we are adding cache chunks, we should never come
+         * here for allocating new chunk buffer.
+         */
+        assert(action == scan_action::SCAN_ACTION_GET);
+
+        chunkvec.emplace_back(next_offset, remaining_length);
+        AZLogDebug("(only/last chunk) [{},{})",
+                   next_offset, next_offset + remaining_length);
+
+        remaining_length = 0;
+    }
+
+    /*
+     * Insert the new chunks in the end.
+     * We cannot do this inside the for loop above as it'll change the chunkmap
+     * while we are traversing it.
+     */
+    for (const auto& chunk : chunkvec) {
+        if (chunk.is_empty) {
+            /*
+             * Other than when we are adding cache chunks, we should never come
+             * here for allocating new chunk buffer.
+             */
+            assert(action == scan_action::SCAN_ACTION_GET);
+
+            AZLogDebug("(adding to chunkmap) [{},{})",
+                       chunk.offset, chunk.offset + chunk.length);
+            /*
+             * This will grab a ref on the alloc_buffer allocated when we
+             * added the chunk to chunkvec. On returning from this function
+             * chunkvec will be destroyed and it'll release its reference,
+             * so the chunkmap reference will be the only reference left.
+             */
+            auto p = chunkmap.try_emplace(chunk.offset, chunk.offset,
+                                          chunk.length, chunk.buffer,
+                                          chunk.alloc_buffer);
+            assert(p.second == true);
+
+            if ((chunk.offset + chunk.length) > _extent_right) {
+                _extent_right = (chunk.offset + chunk.length);
+                AZLogDebug("_extent_right: {}", _extent_right);
+            }
+        }
+    }
+
+    /*
+     * Delete chunks in the range [begin_delete, end_delete).
+     */
+    if (action == scan_action::SCAN_ACTION_RELEASE) {
+        if (begin_delete != chunkmap.end()) {
+            for (auto _it = begin_delete; _it != end_delete; ++_it) {
+                bc = &(_it->second);
+                AZLogDebug("(freeing chunk) [{},{}) b:{} a:{}",
+                           bc->offset, bc->offset + bc->length,
+                           fmt::ptr(bc->buffer),
+                           fmt::ptr(bc->alloc_buffer.get()));
+            }
+
+            // Delete the entire range.
+            chunkmap.erase(begin_delete, end_delete);
+        }
+    } else {
+        assert((begin_delete == chunkmap.end()) &&
+               (end_delete == chunkmap.end()));
+    }
+
+    /*
+     * If we have a chunk_after create it now?
+     * chunk_after is the chunk created when some part from within a chunk
+     * is deleted (not touching either edge).
+     */
+    if (chunk_after) {
+            // Only possible when we release a byte range within a chunk.
+            assert(action == scan_action::SCAN_ACTION_RELEASE);
+
+            AZLogDebug("(chunk after insert) [{},{})",
+                       chunk_after->offset,
+                       chunk_after->offset + chunk_after->length);
+            const auto p = chunkmap.try_emplace(chunk_after->offset,
+                                                chunk_after->offset,
+                                                chunk_after->length,
+                                                chunk_after->buffer,
+                                                chunk_after->alloc_buffer);
+            assert(p.second == true);
+
+            delete chunk_after;
+    }
+
+    if (action == scan_action::SCAN_ACTION_GET) {
+        /*
+         * If left edge is not set, set it now.
+         */
+        if (_extent_left == AZNFSC_BAD_OFFSET) {
+            assert(lookback_it != chunkmap.end());
+            do {
+                bc = &(lookback_it->second);
+
+                if ((_extent_left != AZNFSC_BAD_OFFSET) &&
+                    ((bc->offset + bc->length) != _extent_left)) {
+                    AZLogDebug("(hit gap) _extent_left: {} rightedge: {}",
+                            _extent_left, (bc->offset + bc->length));
+                    break;
+                }
+
+                _extent_left = bc->offset;
+                AZLogDebug("_extent_left: {}", _extent_left);
+            } while (lookback_it-- != chunkmap.begin());
+        }
+
+        /*
+         * Set/update extent right edge.
+         */
+        for (; it != chunkmap.end(); ++it) {
+            bc = &(it->second);
+
+            if ((_extent_right != AZNFSC_BAD_OFFSET) &&
+                (bc->offset != _extent_right)) {
+                AZLogDebug("(hit gap) _extent_right: {} leftedge: {}",
+                        _extent_right, bc->offset);
+                break;
+            }
+
+            _extent_right = bc->offset + bc->length;
+            AZLogDebug("_extent_right: {}", _extent_right);
+        }
+
+        if (extent_left) {
+            *extent_left = _extent_left;
+        }
+
+        if (extent_right) {
+            *extent_right = _extent_right;
+        }
+
+    }
+
+    return (action == scan_action::SCAN_ACTION_GET)
+                ? chunkvec : std::vector<bytes_chunk>();
+}
+
+/**
+ * Generate a random number in the range [min, max].
+ */
+static uint64_t random_number(uint64_t min, uint64_t max)
+{
+    static std::mt19937 gen((uint64_t) std::chrono::system_clock::now().time_since_epoch().count());
+    return min + (gen() % (max - min + 1));
+}
+
+static bool is_read()
+{
+    // 60:40 R:W.
+    return random_number(0, 100) <= 60;
+}
+
+static void cache_read(bytes_chunk_cache& cache,
+                       uint64_t offset,
+                       uint64_t length)
+{
+    std::vector<bytes_chunk> v;
+    uint64_t l, r;
+
+    AZLogDebug("=====> cache_read({}, {})", offset, offset+length);
+    v = cache.get(offset, length, &l, &r);
+    // At least one chunk.
+    assert(v.size() >= 1);
+    assert(v[0].offset == offset);
+    assert(l <= v[0].offset);
+
+    // Sanitize the returned chunkvec.
+    uint64_t prev_chunk_right_edge = AZNFSC_BAD_OFFSET;
+    uint64_t total_length = 0;
+
+    for (auto e : v) {
+        assert(e.length > 0);
+        assert(e.length <= AZNFSC_MAX_CHUNK_SIZE);
+
+        total_length += e.length;
+
+        // Chunks must be contiguous.
+        if (prev_chunk_right_edge != AZNFSC_BAD_OFFSET) {
+            assert(e.offset == prev_chunk_right_edge);
+        }
+        prev_chunk_right_edge = e.offset + e.length;
+        assert(r >= prev_chunk_right_edge);
+    }
+
+    assert(total_length == length);
+
+    AZLogDebug("=====> cache_read({}, {}): l={} r={} vec={}",
+               offset, offset+length, l, r, v.size());
+}
+
+static void cache_write(bytes_chunk_cache& cache,
+                        uint64_t offset,
+                        uint64_t length)
+{
+    std::vector<bytes_chunk> v;
+    uint64_t l, r;
+
+    AZLogDebug("=====> cache_write({}, {})", offset, offset+length);
+    v = cache.get(offset, length, &l, &r);
+    // At least one chunk.
+    assert(v.size() >= 1);
+    assert(v[0].offset == offset);
+    assert(l <= v[0].offset);
+
+    // Sanitize the returned chunkvec.
+    uint64_t prev_chunk_right_edge = AZNFSC_BAD_OFFSET;
+    uint64_t total_length = 0;
+
+    for (auto e : v) {
+        assert(e.length > 0);
+        assert(e.length <= AZNFSC_MAX_CHUNK_SIZE);
+
+        total_length += e.length;
+
+        // Chunks must be contiguous.
+        if (prev_chunk_right_edge != AZNFSC_BAD_OFFSET) {
+            assert(e.offset == prev_chunk_right_edge);
+        }
+        prev_chunk_right_edge = e.offset + e.length;
+        assert(r >= prev_chunk_right_edge);
+    }
+
+    assert(total_length == length);
+
+    AZLogDebug("=====> cache_write({}, {}): l={} r={} vec={}",
+               offset, offset+length, l, r, v.size());
+    AZLogDebug("=====> cache_release({}, {})", offset, offset+length);
+    cache.release(offset, length);
+}
+
+/* static */
+int bytes_chunk_cache::unit_test()
+{
+    std::vector<bytes_chunk> v;
+    bytes_chunk_cache cache;
+    uint64_t l, r;
+
+#define ASSERT_NEW(chunk, start, end) \
+do { \
+    assert(chunk.offset == start); \
+    assert(chunk.length == end-start); \
+    assert(chunk.is_empty); \
+} while (0)
+
+#define ASSERT_EXISTING(chunk, start, end) \
+do { \
+    assert(chunk.offset == start); \
+    assert(chunk.length == end-start); \
+    assert(!(chunk.is_empty)); \
+} while (0)
+
+#define ASSERT_EXTENT(left, right) \
+do { \
+    assert(l == left); \
+    assert(r == right); \
+} while (0)
+
+#define PRINT_CHUNK(chunk) \
+        AZLogInfo("[{},{}){} <{}>", chunk.offset,\
+                  chunk.offset + chunk.length,\
+                  chunk.is_empty ? " [Empty]" : "", \
+                  fmt::ptr(chunk.buffer))
+
+    /*
+     * Get cache chunks covering range [0, 300).
+     * Since the cache is empty, it'll add a new empty chunk and return that.
+     * The newly added chunk is also the largest contiguous block containing
+     * the chunk.
+     */
+    AZLogInfo("========== [Get] --> (0, 300) ==========");
+    v = cache.get(0, 300, &l, &r);
+    assert(v.size() == 1);
+
+    ASSERT_EXTENT(0, 300);
+    ASSERT_NEW(v[0], 0, 300);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Release data range [0, 100).
+     * After this the cache should have chunk [100, 300).
+     */
+    AZLogInfo("========== [Release] --> (0, 100) ==========");
+    cache.release(0, 100);
+
+    /*
+     * Release data range [200, 300).
+     * After this the cache should have chunk [100, 200).
+     */
+    AZLogInfo("========== [Release] --> (200, 100) ==========");
+    cache.release(200, 100);
+
+    /*
+     * Get cache chunks covering range [100, 200).
+     * This will return the (only) existing chunk.
+     * The newly added chunk is also the largest contiguous block containing
+     * the chunk.
+     */
+    AZLogInfo("========== [Get] --> (100, 100) ==========");
+    v = cache.get(100, 100, &l, &r);
+    assert(v.size() == 1);
+
+    ASSERT_EXTENT(100, 200);
+    ASSERT_EXISTING(v[0], 100, 200);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Get cache chunks covering range [50, 150).
+     * This should return 2 chunks:
+     * 1. Newly allocated chunk [50, 100).
+     * 2. Existing chunk data from [100, 150).
+     *
+     * The largest contiguous block containing the requested chunk is [50, 200).
+     */
+    AZLogInfo("========== [Get] --> (50, 100) ==========");
+    v = cache.get(50, 100, &l, &r);
+    assert(v.size() == 2);
+
+    ASSERT_EXTENT(50, 200);
+    ASSERT_NEW(v[0], 50, 100);
+    ASSERT_EXISTING(v[1], 100, 150);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Get cache chunks covering range [250, 300).
+     * This should return 1 chunk:
+     * 1. Newly allocated chunk [250, 300).
+     *
+     * The largest contiguous block containing the requested chunk is [250, 300).
+     */
+    AZLogInfo("========== [Get] --> (250, 50) ==========");
+    v = cache.get(250, 50, &l, &r);
+    assert(v.size() == 1);
+
+    ASSERT_EXTENT(250, 300);
+    ASSERT_NEW(v[0], 250, 300);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Get cache chunks covering range [0, 50).
+     * This should return 1 chunk:
+     * 1. Newly allocated chunk [0, 50).
+     *
+     * The largest contiguous block containing the requested chunk is [0, 200).
+     */
+    AZLogInfo("========== [Get] --> (0, 50) ==========");
+    v = cache.get(0, 50, &l, &r);
+    assert(v.size() == 1);
+
+    ASSERT_EXTENT(0, 200);
+    ASSERT_NEW(v[0], 0, 50);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Get cache chunks covering range [150, 275).
+     * This should return following chunks:
+     * 1. Existing chunk [150, 200).
+     * 2. Newly allocated chunk [200, 250).
+     * 3. Existing chunk [250, 275).
+     *
+     * The largest contiguous block containing the requested chunk is [0, 300).
+     */
+    AZLogInfo("========== [Get] --> (150, 125) ==========");
+    v = cache.get(150, 125, &l, &r);
+    assert(v.size() == 3);
+
+    ASSERT_EXTENT(0, 300);
+    ASSERT_EXISTING(v[0], 150, 200);
+    ASSERT_NEW(v[1], 200, 250);
+    ASSERT_EXISTING(v[2], 250, 275);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Release data range [0, 175).
+     * After this the cache should have the following chunk:
+     * 1. [175, 200).
+     * 2. [200, 250).
+     * 3. [250, 300).
+     */
+    AZLogInfo("========== [Release] --> (0, 175) ==========");
+    cache.release(0, 175);
+
+    /*
+     * Get cache chunks covering range [100, 280).
+     * This should return following chunks:
+     * 1. Newly allocated chunk [100, 175).
+     * 2. Existing chunk [175, 200).
+     * 3. Existing chunk [200, 250).
+     * 4. Existing chunk [250, 280).
+     *
+     * The largest contiguous block containing the requested chunk is [100, 300).
+     */
+    AZLogInfo("========== [Get] --> (100, 180) ==========");
+    v = cache.get(100, 180, &l, &r);
+    assert(v.size() == 4);
+
+    ASSERT_EXTENT(100, 300);
+    ASSERT_NEW(v[0], 100, 175);
+    ASSERT_EXISTING(v[1], 175, 200);
+    ASSERT_EXISTING(v[2], 200, 250);
+    ASSERT_EXISTING(v[3], 250, 280);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Get cache chunks covering range [0, 350).
+     * This should return following chunks:
+     * 1. Newly allocated chunk [0, 100).
+     * 2. Existing chunk [100, 175).
+     * 3. Existing chunk [175, 200).
+     * 4. Existing chunk [200, 250).
+     * 5. Existing chunk [250, 300).
+     * 6. Newly allocated chunk [300, 350).
+     *
+     * The largest contiguous block containing the requested chunk is [0, 350).
+     */
+    AZLogInfo("========== [Get] --> (0, 350) ==========");
+    v = cache.get(0, 350, &l, &r);
+    assert(v.size() == 6);
+
+    ASSERT_EXTENT(0, 350);
+    ASSERT_NEW(v[0], 0, 100);
+    ASSERT_EXISTING(v[1], 100, 175);
+    ASSERT_EXISTING(v[2], 175, 200);
+    ASSERT_EXISTING(v[3], 200, 250);
+    ASSERT_EXISTING(v[4], 250, 300);
+    ASSERT_NEW(v[5], 300, 350);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Release data range [50, 225).
+     * After this the cache should have the following chunks:
+     * 1. [0, 50).
+     * 2. [225, 250).
+     * 3. [250, 300).
+     * 4. [300, 350).
+     */
+    AZLogInfo("========== [Release] --> (50, 175) ==========");
+    cache.release(50, 175);
+
+    /*
+     * Get cache chunks covering range [0, 325).
+     * This should return following chunks:
+     * 1. Existing chunk [0, 50).
+     * 2. Newly allocated chunk [50, 225).
+     * 3. Existing chunk [225, 250).
+     * 4. Existing chunk [250, 300).
+     * 5. Existing chunk [300, 325).
+     *
+     * The largest contiguous block containing the requested chunk is [0, 350).
+     */
+    AZLogInfo("========== [Get] --> (0, 325) ==========");
+    v = cache.get(0, 325, &l, &r);
+    assert(v.size() == 5);
+
+    ASSERT_EXTENT(0, 350);
+    ASSERT_EXISTING(v[0], 0, 50);
+    ASSERT_NEW(v[1], 50, 225);
+    ASSERT_EXISTING(v[2], 225, 250);
+    ASSERT_EXISTING(v[3], 250, 300);
+    ASSERT_EXISTING(v[4], 300, 325);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Release data range [0, 349).
+     * After this the cache should have the following chunks:
+     * 1. [349, 350).
+     */
+    AZLogInfo("========== [Release] --> (0, 349) ==========");
+    cache.release(0, 349);
+
+    /*
+     * Get cache chunks covering range [349, 350).
+     * This should return following chunks:
+     * 1. Existing chunk [349, 350).
+     *
+     * The largest contiguous block containing the requested chunk is [349, 350).
+     */
+    AZLogInfo("========== [Get] --> (349, 1) ==========");
+    v = cache.get(349, 1, &l, &r);
+    assert(v.size() == 1);
+
+    ASSERT_EXTENT(349, 350);
+    ASSERT_EXISTING(v[0], 349, 350);
+
+    for (auto e : v) {
+        PRINT_CHUNK(e);
+    }
+
+    /*
+     * Now run some random cache get/release to stress test the cache.
+     */
+    AZLogInfo("========== Starting cache stress  ==========");
+
+    for (int i = 0; i < 10'000'000; i++) {
+        AZLogDebug("\n\n ----[ {} ]----------\n", i);
+
+        const uint64_t offset = random_number(0, 100'000'000);
+        const uint64_t length = random_number(1, AZNFSC_MAX_CHUNK_SIZE);
+
+        if (is_read()) {
+            cache_read(cache, offset, length);
+        } else {
+            cache_write(cache, offset, length);
+        }
+    }
+
+    AZLogInfo("========== Cache stress successful!  ==========");
+
+    return 0;
+}
+
+#ifdef DEBUG_FILE_CACHE
+static int _i = bytes_chunk_cache::unit_test();
+#endif
+
+}

--- a/nfs/src/main.cpp
+++ b/nfs/src/main.cpp
@@ -435,7 +435,7 @@ static void aznfsc_ll_readdir(fuse_req_t req,
                               off_t off,
                               struct fuse_file_info *fi)
 {
-    AZLogInfo("Readdir called off: {} sz {}", off, size);
+    AZLogInfo("aznfsc_ll_readdir: Readdir called off: {} sz {} ino {}", off, size, ino);
 
     auto client = reinterpret_cast<struct nfs_client*>(fuse_req_userdata(req));
     client->readdir(req, ino, size, off, fi);
@@ -681,7 +681,7 @@ static void aznfsc_ll_readdirplus(fuse_req_t req,
                                   off_t off,
                                   struct fuse_file_info *fi)
 {
-    AZLogInfo("Readdirplus called, off: {} size {}", off, size);
+    AZLogInfo(" aznfsc_ll_readdirplus: Readdirplus called, off: {} size {} ino {}", off, size, ino);
 
     auto client = reinterpret_cast<struct nfs_client*>(fuse_req_userdata(req));
     client->readdirplus(req, ino, size, off, fi);

--- a/nfs/src/main.cpp
+++ b/nfs/src/main.cpp
@@ -435,10 +435,10 @@ static void aznfsc_ll_readdir(fuse_req_t req,
                               off_t off,
                               struct fuse_file_info *fi)
 {
-    /*
-    * TODO: Fill me.
-    */
-    fuse_reply_err(req, ENOSYS);
+    AZLogInfo("Readdir called");
+
+    auto client = reinterpret_cast<struct nfs_client*>(fuse_req_userdata(req));
+    client->readdir(req, ino, size, off, fi);
 }
 
 static void aznfsc_ll_releasedir(fuse_req_t req,
@@ -681,10 +681,10 @@ static void aznfsc_ll_readdirplus(fuse_req_t req,
                                   off_t off,
                                   struct fuse_file_info *fi)
 {
-    /*
-     * TODO: Fill me.
-     */
-    fuse_reply_err(req, ENOSYS);
+    AZLogInfo("Readdirplus called");
+
+    auto client = reinterpret_cast<struct nfs_client*>(fuse_req_userdata(req));
+    client->readdirplus(req, ino, size, off, fi);
 }
 
 void aznfsc_ll_copy_file_range(fuse_req_t req,

--- a/nfs/src/main.cpp
+++ b/nfs/src/main.cpp
@@ -435,7 +435,7 @@ static void aznfsc_ll_readdir(fuse_req_t req,
                               off_t off,
                               struct fuse_file_info *fi)
 {
-    AZLogInfo("Readdir called");
+    AZLogInfo("Readdir called off: {} sz {}", off, size);
 
     auto client = reinterpret_cast<struct nfs_client*>(fuse_req_userdata(req));
     client->readdir(req, ino, size, off, fi);
@@ -681,7 +681,7 @@ static void aznfsc_ll_readdirplus(fuse_req_t req,
                                   off_t off,
                                   struct fuse_file_info *fi)
 {
-    AZLogInfo("Readdirplus called");
+    AZLogInfo("Readdirplus called, off: {} size {}", off, size);
 
     auto client = reinterpret_cast<struct nfs_client*>(fuse_req_userdata(req));
     client->readdirplus(req, ino, size, off, fi);

--- a/nfs/src/nfs_client.cpp
+++ b/nfs/src/nfs_client.cpp
@@ -6,12 +6,6 @@
 
 #define RSTATUS(r) ((r) ? (r)->status : NFS3ERR_SERVERFAULT)
 
-    nfs_client::nfs_client() :
-        transport(this)
-    {
-        //read_dir_cache = readdir_cache::get_instance(this);
-    }
-
 // The user should first init the client class before using it.
 bool nfs_client::init()
 {

--- a/nfs/src/nfs_client.cpp
+++ b/nfs/src/nfs_client.cpp
@@ -101,9 +101,39 @@ void nfs_client::setattr(
     tsk->run_setattr();
 }
 
+void nfs_client::readdir(
+    fuse_req_t req,
+    fuse_ino_t inode,
+    size_t size,
+    off_t offset,
+    struct fuse_file_info* file)
+{
+    struct rpc_task* tsk = nullptr;
+    rpc_task_helper->get_rpc_task_instance(&tsk);
+
+    assert (tsk != nullptr);
+    tsk->set_readdir(this, req, inode, size, offset, file);
+    tsk->run_readdir();
+}
+
+void nfs_client::readdirplus(
+    fuse_req_t req,
+    fuse_ino_t inode,
+    size_t size,
+    off_t offset,
+    struct fuse_file_info* file)
+{
+    struct rpc_task* tsk = nullptr;
+    rpc_task_helper->get_rpc_task_instance(&tsk);
+
+    assert (tsk != nullptr);
+    tsk->set_readdirplus(this, req, inode, size, offset, file);
+    tsk->run_readdirplus();
+}
+
 //
 // Creates a new inode for the given fh and passes it to fuse layer.
-// This will be called by the APIs which much return a filehandle back to the client
+// This will be called by the APIs which must return a filehandle back to the client
 // like lookup, create etc.
 //
 void nfs_client::reply_entry(

--- a/nfs/src/nfs_client.cpp
+++ b/nfs/src/nfs_client.cpp
@@ -30,7 +30,7 @@ bool nfs_client::init()
 
     // initialiaze the root file handle.
     // TODO: Take care of freeing this. Should this be freed in the ~nfs_client()?
-    root_fh = new nfs_inode(nfs_get_rootfh(transport.get_nfs_context()) /*, 1  ino will be 1 for root */);
+    root_fh = new nfs_inode(nfs_get_rootfh(transport.get_nfs_context()) /*, 1  ino will be 1 for root */, this);
     root_fh->set_inode(FUSE_ROOT_ID);
     //AZLogInfo("Obtained root fh is {}", root_fh->get_fh());
 
@@ -145,7 +145,7 @@ void nfs_client::reply_entry(
     {
         // TODO: When should this be freed? This should be freed when the ino is freed,
         // 	 but decide when should that be done?
-        nfs_ino = new nfs_inode(fh);
+        nfs_ino = new nfs_inode(fh, this);
         nfs_ino->set_inode((fuse_ino_t)nfs_ino);
     }
     else

--- a/nfs/src/nfs_client.cpp
+++ b/nfs/src/nfs_client.cpp
@@ -115,11 +115,9 @@ void nfs_client::readdir(
     off_t offset,
     struct fuse_file_info* file)
 {
-    struct rpc_task* tsk = nullptr;
-    rpc_task_helper->get_rpc_task_instance(&tsk);
+    struct rpc_task *tsk = rpc_task_helper->alloc_rpc_task();
 
-    assert (tsk != nullptr);
-    tsk->set_readdir(this, req, inode, size, offset, file);
+    tsk->init_readdir(req, inode, size, offset, file);
     tsk->run_readdir();
 }
 
@@ -130,11 +128,9 @@ void nfs_client::readdirplus(
     off_t offset,
     struct fuse_file_info* file)
 {
-    struct rpc_task* tsk = nullptr;
-    rpc_task_helper->get_rpc_task_instance(&tsk);
+    struct rpc_task *tsk = rpc_task_helper->alloc_rpc_task();
 
-    assert (tsk != nullptr);
-    tsk->set_readdirplus(this, req, inode, size, offset, file);
+    tsk->init_readdirplus(req, inode, size, offset, file);
     tsk->run_readdirplus();
 }
 

--- a/nfs/src/nfs_client.cpp
+++ b/nfs/src/nfs_client.cpp
@@ -9,7 +9,7 @@
     nfs_client::nfs_client() :
         transport(this)
     {
-        read_dir_cache = readdir_cache::get_instance(this);
+        //read_dir_cache = readdir_cache::get_instance(this);
     }
 
 // The user should first init the client class before using it.

--- a/nfs/src/nfs_client.cpp
+++ b/nfs/src/nfs_client.cpp
@@ -2,8 +2,15 @@
 #include "nfs_client.h"
 #include "nfs_internal.h"
 #include "rpc_task.h"
+#include "rpc_readdir.h"
 
 #define RSTATUS(r) ((r) ? (r)->status : NFS3ERR_SERVERFAULT)
+
+    nfs_client::nfs_client() :
+        transport(this)
+    {
+        read_dir_cache = readdir_cache::get_instance(this);
+    }
 
 // The user should first init the client class before using it.
 bool nfs_client::init()

--- a/nfs/src/nfs_inode.cpp
+++ b/nfs/src/nfs_inode.cpp
@@ -43,7 +43,7 @@ bool nfs_inode::purge_readdircache_if_required()
 
     if (should_update_mtime)
     {
-        success = readdirectory_cache::make_getattr_call(inode, attr);
+        success = readdirectory_cache::make_getattr_call(ino, attr);
         // Issue a getattr call to the server to fetch the directory mtime.
     }
 

--- a/nfs/src/nfs_inode.cpp
+++ b/nfs/src/nfs_inode.cpp
@@ -52,9 +52,9 @@ bool nfs_inode::purge_readdircache_if_required()
         if (!readdirectory_cache::are_mtimes_equal(&dirent->attributes, &attr))
         {
             /*
-            * Purge the cache since the directory mtime has changed/
-            * This indicates that the directory has changed.
-            */
+             * Purge the cache since the directory mtime has changed/
+             * This indicates that the directory has changed.
+             */
             goto purge_cache;
         }
 
@@ -73,23 +73,20 @@ purge_cache:
     return true;
 }
 
-
-// Purge the readdir cache.
-// TODO: For now we purge the entire cache. This can be later changed to purge parts of cache.
+/*
+ * Purge the readdir cache.
+ *  TODO: For now we purge the entire cache. This can be later changed to purge
+ *        parts of cache.
+ */
 void nfs_inode::purge()
 {
-    // Reset the shared pointer to release the resource
-//    dircache_handle.reset();
-
-  //  dircache_handle = std::make_shared<readdirectory_cache>();
-dircache_handle->clear();
+    dircache_handle->clear();
 }
 
 void nfs_inode::lookup_readdircache(
-
-    cookie3 cookie_ /* offset in the directory from which the directory should be listed*/,
-    size_t max_size /* maximum size of entries to be returned*/,
-    std::vector<directory_entry* >& results /* dir entries listed*/,
+    cookie3 cookie_,
+    size_t max_size,
+    std::vector<directory_entry* >& results,
     bool& eof,
     bool skip_attr_size)
 {
@@ -133,7 +130,6 @@ void nfs_inode::lookup_readdircache(
     }
     eof = dircache_handle->get_eof();
     AZLogDebug("Buffer exhaust: Num of entries returned from cache {}", num_of_entries_found_in_cache);
-
 }
 
 #endif /* __NFS_INODE__ */

--- a/nfs/src/nfs_inode.cpp
+++ b/nfs/src/nfs_inode.cpp
@@ -1,0 +1,139 @@
+#ifndef __NFS_INODE__
+#define __NFS_INODE__
+
+#include "nfs_inode.h"
+
+bool nfs_inode::purge_readdircache_if_required()
+{
+    struct directory_entry* dirent = nullptr;
+    bool success = false;
+    struct stat attr;
+
+    /*
+     * For now the only prune condition check is the directory mtime.
+     * This function can later be extended to add more conditions.
+     */
+    bool should_update_mtime = false;
+    {
+        bool found = dircache_handle->get_entry_at(1 /* cookie*/, &dirent); // cookie 1 represent '.', hence this gets us cached dir mtime.
+        if (!found)
+        {
+            /*
+             * cookie = 1 refers to the current directory '.'.
+             * This entry should never be purged from the cache, else we will not know the cached
+             * directory mtime.
+             * If we encounter such a state, just purge the complete cache and proceed.
+             */
+            goto purge_cache;
+        }
+
+        const std::time_t now = std::time(nullptr);
+        const std::time_t last_mtimecheck = dircache_handle->get_lastmtime();
+        assert (now >= last_mtimecheck);
+        if (std::difftime(now, last_mtimecheck) > 30) /*sec. TODO: Add #define for this */
+        {
+            should_update_mtime = true;
+        }
+        else
+        {
+            // No need to do any mtime check, just return.
+            return false;
+        }
+    }
+
+    if (should_update_mtime)
+    {
+        success = readdirectory_cache::make_getattr_call(inode, attr);
+        // Issue a getattr call to the server to fetch the directory mtime.
+    }
+
+    if (success)
+    {
+        if (!readdirectory_cache::are_mtimes_equal(&dirent->attributes, &attr))
+        {
+            /*
+            * Purge the cache since the directory mtime has changed/
+            * This indicates that the directory has changed.
+            */
+            goto purge_cache;
+        }
+
+        // Update the mtime.
+        dircache_handle->set_mtime();
+        return false;
+    }
+    else
+    {
+        // TODO: What should we do if getattr call fails?
+        return false;
+    }
+
+purge_cache:
+    purge();
+    return true;
+}
+
+
+// Purge the readdir cache.
+// TODO: For now we purge the entire cache. This can be later changed to purge parts of cache.
+void nfs_inode::purge()
+{
+    // Reset the shared pointer to release the resource
+//    dircache_handle.reset();
+
+  //  dircache_handle = std::make_shared<readdirectory_cache>();
+dircache_handle->clear();
+}
+
+void nfs_inode::lookup_readdircache(
+
+    cookie3 cookie_ /* offset in the directory from which the directory should be listed*/,
+    size_t max_size /* maximum size of entries to be returned*/,
+    std::vector<directory_entry* >& results /* dir entries listed*/,
+    bool& eof,
+    bool skip_attr_size)
+{
+    // Check if the cache should be purged.
+    purge_readdircache_if_required();
+
+    int num_of_entries_found_in_cache = 0;
+
+    size_t rem_size = max_size;
+    while (rem_size > 0)
+    {
+        struct directory_entry* entry;
+        bool found = dircache_handle->lookup(cookie_, &entry);
+        if (found)
+        {
+            const size_t curr_entry_size = entry->get_size(skip_attr_size);
+            if (rem_size >= curr_entry_size)
+            {
+                num_of_entries_found_in_cache++;
+
+                results.push_back(entry);
+            }
+            else
+            {
+                // We have populated the maximum entries requested, hence break.
+                break;
+            }
+            rem_size -= curr_entry_size;
+            cookie_++;
+        }
+        else
+        {
+            AZLogDebug("Traversed map: Num of entries returned from cache {}", num_of_entries_found_in_cache);
+
+            /*
+             * If we don't find the current cookie, then we will not find the next
+             * ones as well since they are stored sequentially.
+             */
+            return;
+        }
+    }
+    eof = dircache_handle->get_eof();
+    AZLogDebug("Buffer exhaust: Num of entries returned from cache {}", num_of_entries_found_in_cache);
+
+}
+
+#endif /* __NFS_INODE__ */

--- a/nfs/src/rpc_task.cpp
+++ b/nfs/src/rpc_task.cpp
@@ -449,7 +449,7 @@ void rpc_task::run_readdirplus()
 }
 
 /*
- * For both application issued readdir and readdirplus calls, this callback will be invoked since we always
+ * For both client issued readdir and readdirplus calls, this callback will be invoked since we always
  * issue readdirplus calls to the backend. This is done to populate the readdir cache.
  * Once this callback is called, it will first populate the readdir cache with the newly fetched entries.
  * Then, it will check for the optype of the rpc_task.
@@ -467,9 +467,9 @@ static void readdirplus_callback(
     bool is_readdirplus_call = false;
     fuse_ino_t inode;
     std::vector<directory_entry*> readdirentries;
-
     int num_of_ele = 0;
     size_t rem_size = 0;
+    
     // Check if the application asked for readdir or readdirplus call.
     if (task->get_op_type() == FUSE_READDIRPLUS)
     {
@@ -688,7 +688,6 @@ void rpc_task::send_readdir_response(std::vector<directory_entry*>& readdirentri
 
     for (const auto& it : readdirentries)
     {
-        // AZLogInfo("Curr entry readdir cookie is {}", it->cookie);
         if ((int)it->cookie <= (int)rpc_api.readdir_task.get_offset())
         {
             /*
@@ -749,7 +748,6 @@ void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdire
         fuse_reply_err(get_req(), ENOMEM);
         return;
     }
-
 
     char *current_buf = buf1;
     size_t rem = sz;

--- a/nfs/src/rpc_task.cpp
+++ b/nfs/src/rpc_task.cpp
@@ -511,7 +511,7 @@ static void readdirplus_callback(
 
             // Create a new nfs inode for the entry
             nfs_inode* nfs_ino;
-            nfs_ino = new nfs_inode(&entry->name_handle.post_op_fh3_u.handle);
+            nfs_ino = new nfs_inode(&entry->name_handle.post_op_fh3_u.handle, task->get_client());
             nfs_ino->set_inode((fuse_ino_t)nfs_ino);
 
             /*

--- a/nfs/src/rpc_task.cpp
+++ b/nfs/src/rpc_task.cpp
@@ -404,3 +404,629 @@ struct nfs_context* rpc_task::get_nfs_context() const
 {
     return client->get_nfs_context();
 }
+
+void rpc_task::set_readdir(struct nfs_client* clt,
+                           fuse_req* request,
+                           fuse_ino_t ino,
+                           size_t size,
+                           off_t offset,
+                           struct fuse_file_info* file)
+{
+    client = clt;
+    req = request;
+    optype = FUSE_READDIR;
+
+    rpc_api.readdir_task.set_inode(ino);
+    rpc_api.readdir_task.set_size(size);
+    rpc_api.readdir_task.set_offset(offset);
+    rpc_api.readdir_task.set_fuse_file(file);
+    rpc_api.readdir_task.set_cookie(offset);
+    rpc_api.readdir_task.set_cookieverf(0);
+}
+
+void rpc_task::set_readdirplus(struct nfs_client* clt,
+                               fuse_req* request,
+                               fuse_ino_t ino,
+                               size_t size,
+                               off_t offset,
+                               struct fuse_file_info* file)
+{
+    client = clt;
+    req = request;
+    optype = FUSE_READDIRPLUS;
+    rpc_api.readdirplus_task.set_inode(ino);
+    rpc_api.readdirplus_task.set_size(size);
+    rpc_api.readdirplus_task.set_offset(offset);
+    rpc_api.readdirplus_task.set_fuse_file(file);
+    // rpc_api.readdirplus_task.set_cookieverf(0);
+    rpc_api.readdirplus_task.set_cookie(offset);
+}
+
+static void getattr_callback(
+    struct rpc_context* /* rpc */,
+    int rpc_status,
+    void* data,
+    void* private_data)
+{
+    auto task = (rpc_task*)private_data;
+    auto res = (GETATTR3res*)data;
+    bool retry;
+
+    if (task->succeeded(rpc_status, RSTATUS(res), retry))
+    {
+        struct stat st;
+        task->get_client()->stat_from_fattr3(
+            &st, &res->GETATTR3res_u.resok.obj_attributes);
+
+        // TODO: Set the Attr timeout to a better value.
+        task->reply_attr(&st, 60/*getAttrTimeout()*/);
+    }
+    else if (retry)
+    {
+        task->run_getattr();
+    }
+    else
+    {
+        // Since the api failed and can no longer be retried, return error reply.
+        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
+    }
+}
+
+static void lookup_callback(
+    struct rpc_context* /* rpc */,
+    int rpc_status,
+    void* data,
+    void* private_data) {
+    auto task = (rpc_task*)private_data;
+    auto res = (LOOKUP3res*)data;
+    bool retry;
+
+    if (rpc_status == RPC_STATUS_SUCCESS && RSTATUS(res) == NFS3ERR_NOENT)
+    {
+        //
+        // Special case for fuse: A "negative entry" refers to an entry that doesn't exist
+        // in the file system. If we want negative cache, we must not return ENOENT,
+        // instead we should return success with zero inode.
+        // When the FUSE kernel module receives a negative entry response, it may cache this
+        // information for a certain duration specified by the entry_timeout parameter.
+        // This caching helps to improve performance by avoiding repeated lookup requests
+        // for entries that are known not to exist.
+        //
+        struct fattr3 dummyAttr;
+        ::memset(&dummyAttr, 0, sizeof(dummyAttr));
+
+        task->get_client()->reply_entry(
+            task,
+            nullptr /* fh */,
+            &dummyAttr,
+            nullptr);
+    }
+    else if(task->succeeded(rpc_status, RSTATUS(res), retry))
+    {
+        assert(res->LOOKUP3res_u.resok.obj_attributes.attributes_follow);
+
+        task->get_client()->reply_entry(
+            task,
+            &res->LOOKUP3res_u.resok.object,
+            &res->LOOKUP3res_u.resok.obj_attributes.post_op_attr_u.attributes,
+            nullptr);
+    }
+    else if(retry)
+    {
+        task->run_lookup();
+    }
+    else
+    {
+        // Since the api failed and can no longer be retried, return error reply.
+        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
+    }
+}
+
+static void createfile_callback(
+    struct rpc_context* /* rpc */,
+    int rpc_status,
+    void* data,
+    void* private_data)
+{
+    auto task = (rpc_task*)private_data;
+    auto res = (CREATE3res*)data;
+    bool retry;
+
+    if (task->succeeded(rpc_status, RSTATUS(res), retry, false))
+    {
+        assert(
+            res->CREATE3res_u.resok.obj.handle_follows &&
+            res->CREATE3res_u.resok.obj_attributes.attributes_follow);
+
+        task->get_client()->reply_entry(
+            task,
+            &res->CREATE3res_u.resok.obj.post_op_fh3_u.handle,
+            &res->CREATE3res_u.resok.obj_attributes.post_op_attr_u.attributes,
+            task->rpc_api.create_task.get_file());
+    }
+    else if (retry)
+    {
+        task->run_create_file();
+    }
+    else
+    {
+        // Since the api failed and can no longer be retried, return error reply.
+        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
+    }
+}
+
+static void setattr_callback(
+    struct rpc_context* /* rpc */,
+    int rpc_status,
+    void* data,
+    void* private_data)
+{
+    auto task = (rpc_task*)private_data;
+    auto res = (SETATTR3res*)data;
+    bool retry;
+
+    if (task->succeeded(rpc_status, RSTATUS(res), retry))
+    {
+        assert(res->SETATTR3res_u.resok.obj_wcc.after.attributes_follow);
+
+        struct stat st;
+        task->get_client()->stat_from_fattr3(
+            &st, &res->SETATTR3res_u.resok.obj_wcc.after.post_op_attr_u.attributes);
+        task->reply_attr(&st, 60 /* TODO: Set reasonable value nfs_client::getAttrTimeout() */);
+    }
+    else if (retry)
+    {
+        task->run_setattr();
+    }
+    else
+    {
+        // Since the api failed and can no longer be retried, return error reply.
+        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
+    }
+}
+
+void mkdir_callback(
+    struct rpc_context* /* rpc */,
+    int rpc_status,
+    void* data,
+    void* private_data) {
+    auto task = (rpc_task*)private_data;
+    auto res = (MKDIR3res*)data;
+    bool retry;
+
+    if (task->succeeded(rpc_status, RSTATUS(res), retry, false))
+    {
+        assert(
+            res->MKDIR3res_u.resok.obj.handle_follows &&
+            res->MKDIR3res_u.resok.obj_attributes.attributes_follow);
+
+        task->get_client()->reply_entry(
+            task,
+            &res->MKDIR3res_u.resok.obj.post_op_fh3_u.handle,
+            &res->MKDIR3res_u.resok.obj_attributes.post_op_attr_u.attributes,
+            nullptr);
+    }
+    else if (retry)
+    {
+        task->run_mkdir();
+    }
+    else
+    {
+        // Since the api failed and can no longer be retried, return error reply.
+        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
+    }
+}
+
+static void readdirplus_callback(
+    struct rpc_context* /* rpc */,
+    int rpc_status,
+    void* data,
+    void* private_data)
+{
+    auto task = (rpc_task*)private_data;
+    auto res = (READDIRPLUS3res*)data;
+    bool retry;
+
+    if (task->succeeded(rpc_status, RSTATUS(res), retry))
+    {
+        // Allocate buffer
+        int num_entries_returned_in_this_iter = 0;
+        size_t sz = task->rpc_api.readdirplus_task.get_size();
+
+        char *buf1 = (char *)malloc(sz);
+        if (!buf1)
+        {
+            fuse_reply_err(task->get_req(), ENOMEM);
+            return;
+        }
+
+        char *current_buff = buf1;
+        size_t rem = sz;
+
+        struct entryplus3* entry = res->READDIRPLUS3res_u.resok.reply.entries;
+
+        while (entry)
+        {
+            if ((int)entry->cookie <= (int)task->rpc_api.readdirplus_task.get_offset())
+            {
+                /*
+                 * Skip entries until the offset
+                 * TODO: See if we need this. Can't we control this thorugh the cookie?
+                 */
+                entry = entry->nextentry;
+                continue;
+            }
+
+            // Structure to hold the attributes.
+            struct stat st;
+            if (entry->name_attributes.attributes_follow)
+            {
+                task->get_client()->stat_from_fattr3(
+                    &st, &entry->name_attributes.post_op_attr_u.attributes);
+            }
+            else
+            {
+                ::memset(&st, 0, sizeof(st));
+            }
+
+            // Create a new inode for the entry
+            nfs_inode* nfs_ino;
+            nfs_ino = new nfs_inode(&entry->name_handle.post_op_fh3_u.handle);
+            nfs_ino->set_inode((fuse_ino_t)nfs_ino);
+
+            struct fuse_entry_param fuseentry;
+            memset(&fuseentry, 0, sizeof(fuseentry));
+            fuseentry.attr = st;
+            fuseentry.ino = (fuse_ino_t)(uintptr_t)nfs_ino;
+
+            /*
+             * TODO: Set the timeout to better value.
+             */
+            fuseentry.attr_timeout = 60;
+            fuseentry.entry_timeout = 60;
+
+            /*
+             * Insert the entry into the buffer.
+             * If the buffer space is less, fuse_add_direntry_plus will not add entry to
+             * the buffer but will still return the space needed to add this entry.
+             */
+            size_t entsize = fuse_add_direntry_plus(task->get_req(),
+                                                    current_buff,
+                                                    rem, /* size left in the buffer */
+                                                    entry->name,
+                                                    &fuseentry,
+                                                    entry->cookie);
+
+            /*
+             * Our buffer size was small and hence we can't add any more entries, so just break the loop.
+             * This also means that we have not inserted the current entry to the direent buffer.
+             */
+            if (entsize > rem)
+            {
+                break;
+            }
+
+            num_entries_returned_in_this_iter++;
+
+            // Increment the buffer pointer to point to the next free space.
+            current_buff += entsize;
+            rem -= entsize;
+
+            // Fetch the next entry.
+            entry = entry->nextentry;
+        }
+
+        fuse_reply_buf(task->get_req(),
+                       buf1,
+                       sz - rem);
+
+        // Free the buffer.
+        free(buf1);
+    }
+    else if (retry)
+    {
+        task->run_readdirplus();
+    }
+    else
+    {
+        // Since the api failed and can no longer be retried, return error reply.
+        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
+    }
+}
+
+static void readdir_callback(
+    struct rpc_context* /* rpc */,
+    int rpc_status,
+    void* data,
+    void* private_data)
+{
+    auto task = (rpc_task*)private_data;
+    auto res = (READDIR3res*)data;
+    bool retry;
+
+    if (task->succeeded(rpc_status, RSTATUS(res), retry))
+    {
+        int num_entries_returned_in_this_iter = 0;
+        size_t sz = task->rpc_api.readdir_task.get_size();
+
+        // Allocate buffer
+        char *buf1 = (char *)malloc(sz);
+        if (!buf1)
+        {
+            fuse_reply_err(task->get_req(), ENOMEM);
+            return;
+        }
+
+        char *current_buf = buf1;
+        size_t rem = sz;
+
+        struct entry3* entry = res->READDIR3res_u.resok.reply.entries;
+
+        while (entry)
+        {
+            if ((int)entry->cookie <= (int)task->rpc_api.readdir_task.get_offset())
+            {
+                /*
+                 * Skip entries until the offset
+                 * TODO: See if we need this. Can't we control this thorugh the cookie?
+                 */
+                entry = entry->nextentry;
+                continue;
+            }
+
+            /*
+             * Insert the entry into the buffer.
+             * If the buffer space is less, fuse_add_direntry will not add entry to
+             * the buffer but will still return the space needed to add this entry.
+             */
+            size_t entsize = fuse_add_direntry(task->get_req(),
+                                               current_buf,
+                                               rem, /* size left in the buffer */
+                                               entry->name,
+                                               nullptr,
+                                               entry->cookie);
+
+            /*
+             * Our buffer size was small and hence we can't add any more entries, so just break the loop.
+             * This also means that we have not inserted the current entry to the direent buffer.
+             */
+            if (entsize > rem)
+            {
+                break;
+            }
+
+            num_entries_returned_in_this_iter++;
+
+            // Increment the buffer pointer to point to the next free space.
+            current_buf += entsize;
+            rem -= entsize;
+            entry = entry->nextentry;
+        }
+
+        fuse_reply_buf(task->get_req(),
+                       buf1,
+                       sz - rem);
+
+        free(buf1);
+    }
+    else if (retry)
+    {
+        task->run_readdir();
+    }
+    else
+    {
+        // Since the api failed and can no longer be retried, return error reply.
+        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
+    }
+}
+
+void rpc_task::run_lookup()
+{
+    bool rpc_retry = false;
+    auto parent_ino = rpc_api.lookup_task.get_parent_inode();
+
+    do {
+        LOOKUP3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.what.dir = get_client()->get_nfs_inode_from_ino(parent_ino)->get_fh();
+        args.what.name = (char*)rpc_api.lookup_task.get_name();
+
+        if (rpc_nfs3_lookup_task(get_rpc_ctx(), lookup_callback, &args, this) == NULL)
+        {
+            // This call fails due to internal issues like OOM etc
+            // and not due to an actual error, hence retry.
+            rpc_retry = true;
+        }
+    } while (rpc_retry);
+}
+
+void rpc_task::run_getattr()
+{
+    bool rpc_retry = false;
+    auto inode = rpc_api.getattr_task.get_inode();
+
+    do {
+        struct GETATTR3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.object = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
+
+        if (rpc_nfs3_getattr_task(get_rpc_ctx(), getattr_callback, &args, this) == NULL)
+        {
+            // This call fails due to internal issues like OOM etc
+            // and not due to an actual error, hence retry.
+            rpc_retry = true;
+        }
+    } while (rpc_retry);
+}
+
+void rpc_task::run_create_file()
+{
+    bool rpc_retry = false;
+    auto parent_ino = rpc_api.create_task.get_parent_inode();
+
+    do {
+        CREATE3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.where.dir = get_client()->get_nfs_inode_from_ino(parent_ino)->get_fh();
+        args.where.name = (char*)rpc_api.create_task.get_name();
+        args.how.mode = (rpc_api.create_task.get_file()->flags & O_EXCL) ? GUARDED : UNCHECKED;
+        args.how.createhow3_u.obj_attributes.mode.set_it = 1;
+        args.how.createhow3_u.obj_attributes.mode.set_mode3_u.mode = rpc_api.create_task.get_mode();
+
+        if (rpc_nfs3_create_task(get_rpc_ctx(), createfile_callback, &args, this) == NULL)
+        {
+            // This call fails due to internal issues like OOM etc
+            // and not due to an actual error, hence retry.
+            rpc_retry = true;
+        }
+    }  while (rpc_retry);
+}
+
+void rpc_task::run_mkdir()
+{
+    bool rpc_retry = false;
+    auto parent_ino = rpc_api.mkdir_task.get_parent_inode();
+
+    do {
+        MKDIR3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.where.dir = get_client()->get_nfs_inode_from_ino(parent_ino)->get_fh();
+        args.where.name = (char*)rpc_api.mkdir_task.get_name();
+        args.attributes.mode.set_it = 1;
+        args.attributes.mode.set_mode3_u.mode = rpc_api.mkdir_task.get_mode();
+
+
+        if (rpc_nfs3_mkdir_task(get_rpc_ctx(), mkdir_callback, &args, this) == NULL)
+        {
+            // This call fails due to internal issues like OOM etc
+            // and not due to an actual error, hence retry.
+            rpc_retry = true;
+        }
+    } while (rpc_retry);
+}
+
+void rpc_task::run_setattr()
+{
+    auto inode = rpc_api.setattr_task.get_inode();
+    auto attr = rpc_api.setattr_task.get_attr();
+    const int valid = rpc_api.setattr_task.get_attr_flags_to_set();
+    bool rpc_retry = false;
+
+    do {
+        SETATTR3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.object = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
+
+        if (valid & FUSE_SET_ATTR_SIZE) {
+            AZLogInfo("Setting size to {}", attr->st_size);
+
+            args.new_attributes.size.set_it = 1;
+            args.new_attributes.size.set_size3_u.size = attr->st_size;
+        }
+
+        if (valid & FUSE_SET_ATTR_MODE) {
+            AZLogInfo("Setting mode to {}", attr->st_mode);
+
+            args.new_attributes.mode.set_it = 1;
+            args.new_attributes.mode.set_mode3_u.mode = attr->st_mode;
+        }
+
+        if (valid & FUSE_SET_ATTR_UID) {
+            AZLogInfo("Setting uid to {}", attr->st_uid);
+            args.new_attributes.uid.set_it = 1;
+            args.new_attributes.uid.set_uid3_u.uid = attr->st_uid;
+        }
+
+        if (valid & FUSE_SET_ATTR_GID) {
+            AZLogInfo("Setting gid to {}", attr->st_gid);
+
+            args.new_attributes.gid.set_it = 1;
+            args.new_attributes.gid.set_gid3_u.gid = attr->st_gid;
+        }
+
+        if (valid & FUSE_SET_ATTR_ATIME) {
+            // TODO: These log are causing crash, look at it later.
+            // AZLogInfo("Setting atime to {}", attr->st_atim.tv_sec);
+
+            args.new_attributes.atime.set_it = SET_TO_CLIENT_TIME;
+            args.new_attributes.atime.set_atime_u.atime.seconds =
+                attr->st_atim.tv_sec;
+            args.new_attributes.atime.set_atime_u.atime.nseconds =
+                attr->st_atim.tv_nsec;
+        }
+
+        if (valid & FUSE_SET_ATTR_MTIME) {
+            // TODO: These log are causing crash, look at it later.
+            // AZLogInfo("Setting mtime to {}", attr->st_mtim.tv_sec);
+
+            args.new_attributes.mtime.set_it = SET_TO_CLIENT_TIME;
+            args.new_attributes.mtime.set_mtime_u.mtime.seconds =
+                attr->st_mtim.tv_sec;
+            args.new_attributes.mtime.set_mtime_u.mtime.nseconds =
+                attr->st_mtim.tv_nsec;
+        }
+
+        if (valid & FUSE_SET_ATTR_ATIME_NOW) {
+            AZLogInfo("Setting atime to now");
+            args.new_attributes.atime.set_it = SET_TO_SERVER_TIME;
+        }
+
+        if (valid & FUSE_SET_ATTR_MTIME_NOW) {
+            AZLogInfo("Setting mtime to now");
+            args.new_attributes.mtime.set_it = SET_TO_SERVER_TIME;
+        }
+
+        if (rpc_nfs3_setattr_task(get_rpc_ctx(), setattr_callback, &args, this) == NULL)
+        {
+            // This call fails due to internal issues like OOM etc
+            // and not due to an actual error, hence retry.
+            rpc_retry = true;
+        }
+    } while (rpc_retry);
+}
+
+void rpc_task::run_readdir()
+{
+
+    bool rpc_retry = false;
+    auto inode = rpc_api.readdir_task.get_inode();
+
+    do {
+        struct READDIR3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.dir = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
+        args.cookie = rpc_api.readdir_task.get_cookie();
+        ::memcpy(&args.cookieverf, rpc_api.readdir_task.get_cookieverf(), sizeof(args.cookieverf));
+        args.count = rpc_api.readdir_task.get_size();
+
+        if (rpc_nfs3_readdir_task(get_rpc_ctx(), readdir_callback, &args, this) == NULL)
+        {
+            // This call fails due to internal issues like OOM etc
+            // and not due to an actual error, hence retry.
+            rpc_retry = true;
+        }
+    } while (rpc_retry);
+}
+
+void rpc_task::run_readdirplus()
+{
+    bool rpc_retry = false;
+    auto inode = rpc_api.readdirplus_task.get_inode();
+
+    do {
+        struct READDIRPLUS3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.dir = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
+        args.cookie = rpc_api.readdirplus_task.get_cookie();
+        ::memcpy(&args.cookieverf, rpc_api.readdirplus_task.get_cookieverf(), sizeof(args.cookieverf));
+        args.dircount = 65536; // TODO: See what this value should be set to.
+        args.maxcount = 65536;
+
+        if (rpc_nfs3_readdirplus_task(get_rpc_ctx(), readdirplus_callback, &args, this) == NULL)
+        {
+            // This call fails due to internal issues like OOM etc
+            // and not due to an actual error, hence retry.
+            rpc_retry = true;
+        }
+    } while (rpc_retry);
+}

--- a/nfs/src/rpc_task.cpp
+++ b/nfs/src/rpc_task.cpp
@@ -61,6 +61,34 @@ void rpc_task::init_setattr(fuse_req* request,
     rpc_api.setattr_task.set_attribute_and_mask(attr, to_set);
 }
 
+void rpc_task::init_readdir(fuse_req *request,
+                            fuse_ino_t ino,
+                            size_t size,
+                            off_t offset,
+                            struct fuse_file_info *file)
+{
+    req = request;
+    optype = FUSE_READDIR;
+    rpc_api.readdir_task.set_inode(ino);
+    rpc_api.readdir_task.set_size(size);
+    rpc_api.readdir_task.set_offset(offset);
+    rpc_api.readdir_task.set_fuse_file(file);
+}
+
+void rpc_task::init_readdirplus(fuse_req *request,
+                                fuse_ino_t ino,
+                                size_t size,
+                                off_t offset,
+                                struct fuse_file_info *file)
+{
+    req = request;
+    optype = FUSE_READDIRPLUS;
+    rpc_api.readdirplus_task.set_inode(ino);
+    rpc_api.readdirplus_task.set_size(size);
+    rpc_api.readdirplus_task.set_offset(offset);
+    rpc_api.readdirplus_task.set_fuse_file(file);
+}
+
 static void getattr_callback(
     struct rpc_context* /* rpc */,
     int rpc_status,
@@ -97,15 +125,15 @@ static void lookup_callback(
 
     if (rpc_status == RPC_STATUS_SUCCESS && RSTATUS(res) == NFS3ERR_NOENT)
     {
-        //
-        // Special case for fuse: A "negative entry" refers to an entry that doesn't exist
-        // in the file system. If we want negative cache, we must not return ENOENT,
-        // instead we should return success with zero inode.
-        // When the FUSE kernel module receives a negative entry response, it may cache this
-        // information for a certain duration specified by the entry_timeout parameter.
-        // This caching helps to improve performance by avoiding repeated lookup requests
-        // for entries that are known not to exist.
-        //
+        /*
+         * Special case for fuse: A "negative entry" refers to an entry that doesn't exist
+         * in the file system. If we want negative cache, we must not return ENOENT,
+         * instead we should return success with zero inode.
+         * When the FUSE kernel module receives a negative entry response, it may cache this
+         * information for a certain duration specified by the entry_timeout parameter.
+         * This caching helps to improve performance by avoiding repeated lookup requests
+         * for entries that are known not to exist.
+         */
         struct fattr3 dummyAttr;
         ::memset(&dummyAttr, 0, sizeof(dummyAttr));
 
@@ -213,8 +241,6 @@ void mkdir_callback(
     }
 }
 
-// This is the task responsible for making the lookup task.
-// lookup_task structure should be populated before calling this function.
 void rpc_task::run_lookup()
 {
     bool rpc_retry = false;
@@ -228,8 +254,10 @@ void rpc_task::run_lookup()
 
         if (rpc_nfs3_lookup_task(get_rpc_ctx(), lookup_callback, &args, this) == NULL)
         {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
+            /*
+             * This call fails due to internal issues like OOM etc
+             * and not due to an actual error, hence retry.
+             */
             rpc_retry = true;
         }
     } while (rpc_retry);
@@ -247,8 +275,10 @@ void rpc_task::run_getattr()
 
         if (rpc_nfs3_getattr_task(get_rpc_ctx(), getattr_callback, &args, this) == NULL)
         {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
+            /*
+             * This call fails due to internal issues like OOM etc
+             * and not due to an actual error, hence retry.
+             */
             rpc_retry = true;
         }
     } while (rpc_retry);
@@ -270,8 +300,10 @@ void rpc_task::run_create_file()
 
         if (rpc_nfs3_create_task(get_rpc_ctx(), createfile_callback, &args, this) == NULL)
         {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
+            /*
+             * This call fails due to internal issues like OOM etc
+             * and not due to an actual error, hence retry.
+             */
             rpc_retry = true;
         }
     }  while (rpc_retry);
@@ -290,11 +322,12 @@ void rpc_task::run_mkdir()
         args.attributes.mode.set_it = 1;
         args.attributes.mode.set_mode3_u.mode = rpc_api.mkdir_task.get_mode();
 
-
         if (rpc_nfs3_mkdir_task(get_rpc_ctx(), mkdir_callback, &args, this) == NULL)
         {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
+            /*
+             * This call fails due to internal issues like OOM etc
+             * and not due to an actual error, hence retry.
+             */
             rpc_retry = true;
         }
     } while (rpc_retry);
@@ -362,19 +395,19 @@ void rpc_task::run_setattr()
         }
 
         if (valid & FUSE_SET_ATTR_ATIME_NOW) {
-            AZLogInfo("Setting atime to now");
             args.new_attributes.atime.set_it = SET_TO_SERVER_TIME;
         }
 
         if (valid & FUSE_SET_ATTR_MTIME_NOW) {
-            AZLogInfo("Setting mtime to now");
             args.new_attributes.mtime.set_it = SET_TO_SERVER_TIME;
         }
 
         if (rpc_nfs3_setattr_task(get_rpc_ctx(), setattr_callback, &args, this) == NULL)
         {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
+            /*
+             * This call fails due to internal issues like OOM etc
+             * and not due to an actual error, hence retry.
+             */
             rpc_retry = true;
         }
     } while (rpc_retry);
@@ -384,17 +417,17 @@ void rpc_task::run_setattr()
 void rpc_task::free_rpc_task()
 {
     switch(get_op_type()) {
-        case FUSE_LOOKUP:
-            rpc_api.lookup_task.release();
-            break;
-        case FUSE_CREATE:
-            rpc_api.create_task.release();
-            break;
-        case FUSE_MKDIR:
-            rpc_api.mkdir_task.release();
-            break;
-        default :
-            break;
+    case FUSE_LOOKUP:
+        rpc_api.lookup_task.release();
+        break;
+    case FUSE_CREATE:
+        rpc_api.create_task.release();
+        break;
+    case FUSE_MKDIR:
+        rpc_api.mkdir_task.release();
+        break;
+    default :
+        break;
     }
     client->get_rpc_task_helper()->free_rpc_task(this);
 }
@@ -405,65 +438,23 @@ struct nfs_context* rpc_task::get_nfs_context() const
     return client->get_nfs_context();
 }
 
-void rpc_task::set_readdir(struct nfs_client* clt,
-                           fuse_req* request,
-                           fuse_ino_t ino,
-                           size_t size,
-                           off_t offset,
-                           struct fuse_file_info* file)
+void rpc_task::run_readdir()
 {
-    client = clt;
-    req = request;
-    optype = FUSE_READDIR;
-
-    rpc_api.readdir_task.set_inode(ino);
-    rpc_api.readdir_task.set_size(size);
-    rpc_api.readdir_task.set_offset(offset);
-    rpc_api.readdir_task.set_fuse_file(file);
-    rpc_api.readdir_task.set_cookie(offset);
-
-    //m_readdirentries.clear();
-    //readdir_result_size = 0;
-    //rpc_api.readdir_task.set_cookieverf(0);
-    //rpc_api.readdir_task.m_results.clear();
-    //rpc_api.readdir_task.result_size = 0;
-    // rpc_api.readdir_task.set_buffer(nullptr);
-    //rpc_api.readdir_task.set_buffer_size(0);
+    get_readdir_entries_from_cache();
 }
 
-void rpc_task::set_readdirplus(struct nfs_client* clt,
-                               fuse_req* request,
-                               fuse_ino_t ino,
-                               size_t size,
-                               off_t offset,
-                               struct fuse_file_info* file)
+void rpc_task::run_readdirplus()
 {
-    client = clt;
-    req = request;
-    optype = FUSE_READDIRPLUS;
-    rpc_api.readdirplus_task.set_inode(ino);
-    rpc_api.readdirplus_task.set_size(size);
-    rpc_api.readdirplus_task.set_offset(offset);
-    rpc_api.readdirplus_task.set_fuse_file(file);
-    // rpc_api.readdirplus_task.set_cookieverf(0);
-    rpc_api.readdirplus_task.set_cookie(offset);
-    //m_readdirentries.clear();
-    //readdir_result_size = 0;
-    //rpc_api.readdir_task.m_results.clear();
-    //rpc_api.readdir_task.result_size = 0;
+    get_readdirplus_entries_from_cache();
 }
-
-
 
 /*
  * For both application issued readdir and readdirplus calls, this callback will be invoked since we always
  * issue readdirplus calls to the backend. This is done to populate the readdir cache.
  * Once this callback is called, it will first populate the readdir cache with the newly fetched entries.
  * Then, it will check for the optype of the rpc_task.
- * If the optyoe is FUSE_READDIRPLUS then it will populate the directory_results vector
- * of the readdirplus task and call send_readdirplus_response.
- * If the optype is FUSE_READDIR  then it will populate the directory_results vector of
- * the readdir task and call send_readdir_response.
+ * If the optype is FUSE_READDIRPLUS then it will populate the results vector and call send_readdirplus_response.
+ * If the optype is FUSE_READDIR  then it will populate the results vector and call send_readdir_response.
  */
 static void readdirplus_callback(
     struct rpc_context* /* rpc */,
@@ -473,77 +464,39 @@ static void readdirplus_callback(
 {
     auto task = (rpc_task*)private_data;
     auto res = (READDIRPLUS3res*)data;
-    bool retry;
     bool is_readdirplus_call = false;
     fuse_ino_t inode;
     std::vector<directory_entry*> readdirentries;
 
+    int num_of_ele = 0;
+    size_t rem_size = 0;
     // Check if the application asked for readdir or readdirplus call.
     if (task->get_op_type() == FUSE_READDIRPLUS)
     {
         inode = task->rpc_api.readdirplus_task.get_inode();
         is_readdirplus_call = true;
+        rem_size = task->rpc_api.readdirplus_task.get_size();
     }
     else
     {
         inode = task->rpc_api.readdir_task.get_inode();
+        rem_size = task->rpc_api.readdir_task.get_size();
     }
 
     struct nfs_inode *nfs_ino = task->get_client()->get_nfs_inode_from_ino(inode);
     assert (nfs_ino != nullptr);
 
-    if (task->succeeded(rpc_status, RSTATUS(res), retry))
+    if (task->succeeded(rpc_status, RSTATUS(res)))
     {
-#if 0
-        // Allocate buffer
-        int num_entries_returned_in_this_iter = 0;
-        size_t sz = task->rpc_api.readdirplus_task.get_size();
-
-        char *buf1 = (char *)malloc(sz);
-        if (!buf1)
-        {
-            fuse_reply_err(task->get_req(), ENOMEM);
-            return;
-        }
-
-        char *current_buff = buf1;
-        size_t rem = sz;
-#endif
         struct entryplus3* entry = res->READDIRPLUS3res_u.resok.reply.entries;
         bool eof = res->READDIRPLUS3res_u.resok.reply.eof;
 
-
-        // Create a shared pointer to be inserted into the cache.
-        //std::shared_ptr<readdirectory_cache> readdircache_handle = task->get_client()->get_readdir_cache()->get(inode);
+        // Get handle to the readdirectory cache.
         std::shared_ptr<readdirectory_cache> readdircache_handle = nfs_ino->dircache_handle;
         assert(readdircache_handle != nullptr);
-        int num_of_ele = 0;
-            size_t rem_size = 0;
-            if (is_readdirplus_call)
-            {
-                rem_size = task->rpc_api.readdirplus_task.get_size();
-            }
-            else
-            {
-                rem_size = task->rpc_api.readdir_task.get_size();
-            }
 
         while (entry)
         {
-#if 0
-            last_cookie = entry->cookie;
-
-            if ((int)entry->cookie <= (int)task->rpc_api.readdirplus_task.get_offset())
-            {
-                AZLogDebug("skipping cookie {}", entry->cookie);
-                /*
-                 * Skip entries until the offset
-                 * TODO: See if we need this. Can't we control this thorugh the cookie?
-                 */
-                entry = entry->nextentry;
-                continue;
-            }
-#endif
             // Structure to hold the attributes.
             struct stat st;
             if (entry->name_attributes.attributes_follow)
@@ -567,40 +520,32 @@ static void readdirplus_callback(
              */
             struct directory_entry* dir_entry = new directory_entry(entry->name, entry->cookie, st, nfs_ino);
 
-            // Add it to the directory_entry vector ONLY if it does not cross the max size limit requested by the application.
+            /*
+             * Add it to the directory_entry vector ONLY if it does not cross the max
+             * size limit requested by the client.
+             */
             const size_t curr_entry_size = dir_entry->get_size();
             if (rem_size >= curr_entry_size)
             {
-                    //task->readdir_result_size += curr_entry_size;
-                    readdirentries.push_back(dir_entry);
-
-                    rem_size -= curr_entry_size;
+                readdirentries.push_back(dir_entry);
+                rem_size -= curr_entry_size;
             }
 
             // Add this to the readdirectory_cache.
             readdircache_handle->add(dir_entry);
             entry = entry->nextentry;
 
-            // TODO: Remove this.
             ++num_of_ele;
         }
 
         AZLogInfo("Num of entries returned by server is {}, result_vector: {}", num_of_ele, readdirentries.size());
 
-        // TODO: See if the cache really needs to store the cookie verifier.
         readdircache_handle->set_cookieverf(&res->READDIRPLUS3res_u.resok.cookieverf);
-
-        // Update this cookie verifier received in the inode.
-        //task->get_client()->get_nfs_inode_from_ino(inode)->set_cookieverf(&res->READDIRPLUS3res_u.resok.cookieverf);
 
         if (eof)
         {
             readdircache_handle->set_eof();
         }
-
-        // Now insert into the readdir cache.
-        // THIS IS NOT NEEDED SINCE WE ARE DIRECTLY MODIFYING THE SHARED POINTER.
-        //read_dir_cache->add(inode, dir_cache);
 
         if (is_readdirplus_call)
         {
@@ -611,64 +556,6 @@ static void readdirplus_callback(
             task->send_readdir_response(readdirentries);
         }
     }
-#if 0
-        // Create a new inode for the entry
-        nfs_inode* nfs_ino;
-        nfs_ino = new nfs_inode(&entry->name_handle.post_op_fh3_u.handle);
-        nfs_ino->set_inode((fuse_ino_t)nfs_ino);
-
-        struct fuse_entry_param fuseentry;
-        memset(&fuseentry, 0, sizeof(fuseentry));
-        fuseentry.attr = st;
-        fuseentry.ino = (fuse_ino_t)(uintptr_t)nfs_ino;
-
-        /*
-         * TODO: Set the timeout to better value.
-         */
-        fuseentry.attr_timeout = 60;
-        fuseentry.entry_timeout = 60;
-
-        /*
-         * Insert the entry into the buffer.
-         * If the buffer space is less, fuse_add_direntry_plus will not add entry to
-         * the buffer but will still return the space needed to add this entry.
-         */
-        size_t entsize = fuse_add_direntry_plus(task->get_req(),
-                                                current_buff,
-                                                rem, /* size left in the buffer */
-                                                entry->name,
-                                                &fuseentry,
-                                                entry->cookie);
-
-        /*
-         * Our buffer size was small and hence we can't add any more entries, so just break the loop.
-         * This also means that we have not inserted the current entry to the direent buffer.
-         */
-        if (entsize > rem)
-        {
-            AZLogDebug("No isze in buf, returning");
-            break;
-        }
-
-        num_entries_returned_in_this_iter++;
-
-        // Increment the buffer pointer to point to the next free space.
-        current_buff += entsize;
-        rem -= entsize;
-
-        // Fetch the next entry.
-        entry = entry->nextentry;
-    }
-
-    AZLogDebug("Last cookie {}", last_cookie);
-
-    fuse_reply_buf(task->get_req(),
-                   buf1,
-                   sz - rem);
-
-    // Free the buffer.
-    free(buf1);
-#endif
     else
     {
         // Since the api failed and can no longer be retried, return error reply.
@@ -676,53 +563,160 @@ static void readdirplus_callback(
     }
 }
 
-#if 0
-rpc_task::send_readdir_response()
+void rpc_task::get_readdir_entries_from_cache()
 {
-    size_t sz = rpc_api.readdir_task.get_size();
+    assert(get_op_type() == FUSE_READDIR);
 
-    char *buf1 = (char *)malloc(sz);
+    bool is_eof = false;
+
+    struct nfs_inode *nfs_ino = get_client()->get_nfs_inode_from_ino(rpc_api.readdirplus_task.get_inode());
+    assert (nfs_ino != nullptr);
+
+    std::vector<directory_entry*> readdirentries;
+
+    nfs_ino->lookup_readdircache(
+        rpc_api.readdir_task.get_offset() + 1, // +1 to return the next entry from where the client requested.
+        rpc_api.readdir_task.get_size(),
+        readdirentries,
+        is_eof,
+        true /* skip_attr_size */);
+
+    // TODO: Send response if eof is set.
+    if (readdirentries.empty())
+    {
+        /*
+         * Read from the backend only if there is no entry present in the cache.
+         * Note : It is okay to send less number of entries than requested since
+         *        the Fuse layer will request for more num of entries later.
+         */
+        fetch_readdir_entries_from_server();
+    }
+    else
+    {
+        // We are done fetching the entries, send the response now.
+        send_readdir_response(readdirentries);
+    }
+}
+
+void rpc_task::get_readdirplus_entries_from_cache()
+{
+    bool is_eof = false;
+    assert(get_op_type() == FUSE_READDIRPLUS);
+    struct nfs_inode *nfs_ino = get_client()->get_nfs_inode_from_ino(rpc_api.readdirplus_task.get_inode());
+    assert (nfs_ino != nullptr);
+
+    std::vector<directory_entry*> readdirentries;
+
+    nfs_ino->lookup_readdircache( rpc_api.readdirplus_task.get_offset()+1,
+                                  rpc_api.readdirplus_task.get_size(),
+                                  readdirentries,
+                                  is_eof);
+
+    // TODO: Send response if eof is set.
+    if (readdirentries.empty())
+    {
+        /*
+         * Read from the backend only if there is no entry present in the cache.
+         * Note : It is okay to send less number of entries than requested since
+         *        the Fuse layer will request for more num of entries later.
+         */
+        fetch_readdir_entries_from_server();
+    }
+    else
+    {
+        // We are done fetching the entries, send the response now.
+        send_readdirplus_response(readdirentries);
+    }
+}
+
+void rpc_task::fetch_readdir_entries_from_server()
+{
+    bool rpc_retry = false;
+    fuse_ino_t inode;
+
+    cookie3 cookie = 0;
+
+    if (get_op_type() == FUSE_READDIR)
+    {
+        inode = rpc_api.readdir_task.get_inode();
+        cookie = rpc_api.readdir_task.get_offset();
+    }
+    else
+    {
+        inode = rpc_api.readdirplus_task.get_inode();
+        cookie = rpc_api.readdirplus_task.get_offset();
+    }
+
+    do {
+        struct READDIRPLUS3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.dir = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
+        args.cookie = cookie;
+        ::memcpy(&args.cookieverf, get_client()->get_nfs_inode_from_ino(inode)->dircache_handle->get_cookieverf(), sizeof(args.cookieverf));
+        args.dircount = 65536; // TODO: Set this to user passed value.
+        args.maxcount = 65536;
+
+        if (rpc_nfs3_readdirplus_task(get_rpc_ctx(), readdirplus_callback, &args, this) == NULL)
+        {
+            /*
+             * This call fails due to internal issues like OOM etc
+             * and not due to an actual error, hence retry.
+             */
+            rpc_retry = true;
+        }
+    } while (rpc_retry);
+}
+
+void rpc_task::send_readdir_response(std::vector<directory_entry*>& readdirentries)
+{
+    assert(get_op_type() == FUSE_READDIR);
+
+    const size_t size = rpc_api.readdir_task.get_size();
+
+// Allocate buffer
+    char *buf1 = (char *)malloc(size);
     if (!buf1)
     {
         fuse_reply_err(get_req(), ENOMEM);
         return;
     }
 
+    char *current_buf = buf1;
+    size_t rem = size;
+    int  num_of_entries_returned = 0;
+    AZLogInfo("Size of readdir result vector is {}", readdirentries.size());
 
-    char *current_buff = buf1;
-    size_t rem = sz;
-
-
-    for (auto it = rpc_api.readdir_task.m_results.begin(); it != rpc_api.readdir_task.m_results.end(); ++it)
+    for (const auto& it : readdirentries)
     {
+        // AZLogInfo("Curr entry readdir cookie is {}", it->cookie);
         if ((int)it->cookie <= (int)rpc_api.readdir_task.get_offset())
         {
             /*
              * Skip entries until the offset
              * TODO: See if we need this. Can't we control this thorugh the cookie?
              */
-            entry = entry->nextentry;
-            AZLogDebug("skipping cookie {}", entry->cookie);
+            //AZLogDebug("skipping cookie {}", it->cookie);
             continue;
         }
-
-
 
         /*
          * Insert the entry into the buffer.
          * If the buffer space is less, fuse_add_direntry will not add entry to
          * the buffer but will still return the space needed to add this entry.
          */
+        struct stat st;
+        ::memset(&st, 0, sizeof(st));
         size_t entsize = fuse_add_direntry(get_req(),
                                            current_buf,
                                            rem, /* size left in the buffer */
                                            it->name,
-                                           &it->attributes,
+                                           &st,
                                            it->cookie);
 
         /*
-         * Our buffer size was small and hence we can't add any more entries, so just break the loop.
-         * This also means that we have not inserted the current entry to the direent buffer.
+         * Our buffer size was small and hence we can't add any more entries,
+         * so just break the loop. This also means that we have not inserted the
+         * current entry to the direent buffer.
          */
         if (entsize > rem)
         {
@@ -732,14 +726,22 @@ rpc_task::send_readdir_response()
         // Increment the buffer pointer to point to the next free space.
         current_buf += entsize;
         rem -= entsize;
+        num_of_entries_returned++;
     }
+
+    AZLogDebug("Num of entries sent in readdir response is {}", num_of_entries_returned);
+
+    fuse_reply_buf(get_req(),
+                   buf1,
+                   size - rem);
+
+    free(buf1);
 }
-#endif
 
 void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdirentries)
 {
     size_t sz = rpc_api.readdirplus_task.get_size();
-     assert(get_op_type() == FUSE_READDIRPLUS);
+    assert(get_op_type() == FUSE_READDIRPLUS);
 
     char *buf1 = (char *)malloc(sz);
     if (!buf1)
@@ -753,8 +755,8 @@ void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdire
     size_t rem = sz;
     int num_of_entries_returned = 0;
 
-    AZLogInfo("Size of readdirplus result vector is {}", readdirentries.size());
-    //for ( auto it = m_readdirentries.begin(); it != m_readdirentries.end(); ++it)
+    AZLogDebug("Size of readdirplus result vector is {}", readdirentries.size());
+
     for (const auto& it : readdirentries)
     {
         if ((int)it->cookie <= (int)rpc_api.readdirplus_task.get_offset())
@@ -763,15 +765,14 @@ void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdire
              * Skip entries until the offset
              * TODO: See if we need this. Can't we control this thorugh the cookie?
              */
-           // entry = entry->nextentry;
-           // AZLogDebug("skipping cookie {}", it->cookie);
+            // AZLogDebug("skipping cookie {}", it->cookie);
             continue;
         }
 
         struct fuse_entry_param fuseentry;
         memset(&fuseentry, 0, sizeof(fuseentry));
         fuseentry.attr = it->attributes;
-        fuseentry.ino = it->nfs_ino->inode;
+        fuseentry.ino = it->nfs_ino->ino;
 
         /*
          * TODO: Set the timeout to better value.
@@ -797,7 +798,7 @@ void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdire
          */
         if (entsize > rem)
         {
-            AZLogDebug("No isze in buf, returning");
+            AZLogDebug("Can't add anymore entries to buffer, space exhausted.");
             break;
         }
 
@@ -814,349 +815,4 @@ void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdire
 
     // Free the buffer.
     free(buf1);
-}
-
-#if 0
-static void readdir_callback(
-    struct rpc_context* /* rpc */,
-    int rpc_status,
-    void* data,
-    void* private_data)
-{
-    auto task = (rpc_task*)private_data;
-    auto res = (READDIR3res*)data;
-    bool retry;
-
-    cookie3 last_cookie = 0;
-
-    if (task->succeeded(rpc_status, RSTATUS(res), retry))
-    {
-        int num_entries_returned_in_this_iter = 0;
-        size_t sz = task->rpc_api.readdir_task.get_size();
-
-        // Allocate buffer
-        char *buf1 = (char *)malloc(sz);
-        if (!buf1)
-        {
-            fuse_reply_err(task->get_req(), ENOMEM);
-            return;
-        }
-
-        char *current_buf = buf1;
-        size_t rem = sz;
-
-        struct entry3* entry = res->READDIR3res_u.resok.reply.entries;
-
-        struct stat st;
-        ::memset(&st, 0, sizeof(st));
-
-        while (entry)
-        {
-            last_cookie = entry->cookie;
-
-            if ((int)entry->cookie <= (int)task->rpc_api.readdir_task.get_offset())
-            {
-                /*
-                 * Skip entries until the offset
-                 * TODO: See if we need this. Can't we control this thorugh the cookie?
-                 */
-                entry = entry->nextentry;
-                AZLogDebug("skipping cookie {}", entry->cookie);
-                continue;
-            }
-
-            /*
-             * Insert the entry into the buffer.
-             * If the buffer space is less, fuse_add_direntry will not add entry to
-             * the buffer but will still return the space needed to add this entry.
-             */
-            size_t entsize = fuse_add_direntry(task->get_req(),
-                                               current_buf,
-                                               rem, /* size left in the buffer */
-                                               entry->name,
-                                               &st,
-                                               entry->cookie);
-
-            /*
-             * Our buffer size was small and hence we can't add any more entries, so just break the loop.
-             * This also means that we have not inserted the current entry to the direent buffer.
-             */
-            if (entsize > rem)
-            {
-                break;
-            }
-
-            num_entries_returned_in_this_iter++;
-
-            // Increment the buffer pointer to point to the next free space.
-            current_buf += entsize;
-            rem -= entsize;
-            entry = entry->nextentry;
-        }
-        AZLogDebug("Last cookie {}",last_cookie );
-
-        fuse_reply_buf(task->get_req(),
-                       buf1,
-                       sz - rem);
-
-        free(buf1);
-    }
-    else if (retry)
-    {
-        task->run_readdir();
-    }
-    else
-    {
-        // Since the api failed and can no longer be retried, return error reply.
-        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
-    }
-}
-#endif
-
-void rpc_task::run_readdir()
-{
-    get_readdir_entries_from_cache();
-#if 0
-    do {
-        struct READDIR3args args;
-        ::memset(&args, 0, sizeof(args));
-        args.dir = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
-        args.cookie = rpc_api.readdir_task.get_cookie();
-        ::memcpy(&args.cookieverf, rpc_api.readdir_task.get_cookieverf(), sizeof(args.cookieverf));
-        args.count = rpc_api.readdir_task.get_size();
-
-        if (rpc_nfs3_readdir_task(get_rpc_ctx(), readdir_callback, &args, this) == NULL)
-        {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
-            rpc_retry = true;
-        }
-    } while (rpc_retry);
-#endif
-}
-
-void rpc_task::get_readdir_entries_from_cache()
-{
-    assert(get_op_type() == FUSE_READDIR);
-
-    bool is_eof = false;
-
-    struct nfs_inode *nfs_ino = get_client()->get_nfs_inode_from_ino(rpc_api.readdirplus_task.get_inode());
-    assert (nfs_ino != nullptr);
-
-    std::vector<directory_entry*> readdirentries;
-
-    /*const bool entry_found =*/ nfs_ino->lookup_readdircache(
-                         rpc_api.readdir_task.get_cookie() + 1 , // TODO: See if this should populate from cookie+1
-                         rpc_api.readdir_task.get_size(),
-                         readdirentries,
-                         //readdir_result_size,
-                         //rpc_api.readdir_task.m_results,
-                         //rpc_api.readdir_task.result_size,
-                         is_eof,
-                         true /* skip_attr_size */);
-#if 0
-    if (!entry_found)
-    {
-        assert (m_readdirentries.empty());
-        assert (readdir_result_size == 0);
-        fetch_readdir_entries_from_server();
-    }
- #endif
-    //if (!size_exhausted && (rpc_api.readdir_task.get_size() > readdir_result_size)/* && !is_eof*/)
-    if (readdirentries.empty())
-    {
-        // Read from the backend only if there is no entry present in the cache.
-        // Note : It is okay even if we send less number of entries. Fuse layer will request for more num of entries later.
-
-        /*
-         * We can return more number of entries to the caller since we have not exceeded the
-         * requested size. Since these entries are not present in the cache, this should be fetched
-         * from the backend.
-         */
-        fetch_readdir_entries_from_server();
-    }
-    else
-    {
-        // We are done fetching all the entries, send the response now.
-        send_readdir_response(readdirentries);
-    }
-}
-
-void rpc_task::get_readdirplus_entries_from_cache()
-{
-    bool is_eof = false;
-     assert(get_op_type() == FUSE_READDIRPLUS);
- //   bool size_exhausted = false;
-    struct nfs_inode *nfs_ino = get_client()->get_nfs_inode_from_ino(rpc_api.readdirplus_task.get_inode());
-    assert (nfs_ino != nullptr);
-
-    std::vector<directory_entry*> readdirentries;
-
-    nfs_ino->lookup_readdircache( rpc_api.readdirplus_task.get_cookie()+1,
-                         rpc_api.readdirplus_task.get_size(),
-                         readdirentries,
-                         //readdir_result_size,
-                         //rpc_api.readdirplus_task.m_results,
-                         //rpc_api.readdirplus_task.result_size,
-                         is_eof);
-                         //size_exhausted);
-
-    //if (!size_exhausted && (rpc_api.readdirplus_task.get_size() > readdir_result_size) /*&& !is_eof */)
-    if (readdirentries.empty())
-    {
-        /*
-         * We can return more number of entries to the caller since we have not exceeded the
-         * requested size. Since these entries are not present in the cache, this should be fetched
-         * from the backend.
-         */
-        fetch_readdir_entries_from_server();
-    }
-    else
-    {
-        send_readdirplus_response(readdirentries);
-    }
-}
-
-void rpc_task::fetch_readdir_entries_from_server()
-{
-    bool rpc_retry = false;
-    fuse_ino_t inode;
-
-    cookie3 cookie = 0;
-    
-    if (get_op_type() == FUSE_READDIR)
-    {
-        inode = rpc_api.readdir_task.get_inode();
-        cookie = rpc_api.readdir_task.get_offset();
-    }
-    else
-    {
-         inode = rpc_api.readdirplus_task.get_inode();
-        cookie = rpc_api.readdirplus_task.get_offset();
-    }
-
-#if 0
-    // Fetch the cookie from where we want to do the listing.
-    if (!m_readdirentries.empty())
-    {
-        cookie = m_readdirentries.back()->cookie;
-    }
-#endif
-    do {
-        struct READDIRPLUS3args args;
-        ::memset(&args, 0, sizeof(args));
-        args.dir = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
-        //args.cookie = rpc_api.readdirplus_task.get_cookie();
-        args.cookie = cookie;
-        ::memcpy(&args.cookieverf, get_client()->get_nfs_inode_from_ino(inode)->dircache_handle->get_cookieverf(), sizeof(args.cookieverf));
-       // ::memcpy(&args.cookieverf, cookieverf, sizeof(args.cookieverf));
-        args.dircount = 65536; // TODO: See what this value should be set to.
-        args.maxcount = 65536;
-
-        if (rpc_nfs3_readdirplus_task(get_rpc_ctx(), readdirplus_callback, &args, this) == NULL)
-        {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
-            rpc_retry = true;
-        }
-    } while (rpc_retry);
-
-}
-
-void rpc_task::send_readdir_response(std::vector<directory_entry*>& readdirentries)
-{
-     assert(get_op_type() == FUSE_READDIR);
-
-    const size_t size = rpc_api.readdir_task.get_size();
-    // Allocate buffer
-    char *buf1 = (char *)malloc(size);
-    if (!buf1)
-    {
-        fuse_reply_err(get_req(), ENOMEM);
-        return;
-    }
-
-    char *current_buf = buf1;
-    size_t rem = size;
-    int  num_of_entries_returned = 0;
-    AZLogInfo("Size of readdir result vector is {}", readdirentries.size());
-
-    for (const auto& it : readdirentries)
-    {
-       // AZLogInfo("Curr entry readdir cookie is {}", it->cookie);
-        if ((int)it->cookie <= (int)rpc_api.readdir_task.get_offset())
-        {
-            /*
-             * Skip entries until the offset
-             * TODO: See if we need this. Can't we control this thorugh the cookie?
-             */
-           // entry = entry->nextentry;
-            //AZLogDebug("skipping cookie {}", it->cookie);
-            continue;
-        }
-        /*
-        * Insert the entry into the buffer.
-        * If the buffer space is less, fuse_add_direntry will not add entry to
-        * the buffer but will still return the space needed to add this entry.
-        */
-        struct stat st;
-        ::memset(&st, 0, sizeof(st));
-        size_t entsize = fuse_add_direntry(get_req(),
-                                           current_buf,
-                                           rem, /* size left in the buffer */
-                                           it->name,
-                                           &st, // TODO: Should we not pass attributes for readdir?
-                                           it->cookie);
-
-        /*
-        * Our buffer size was small and hence we can't add any more entries, so just break the loop.
-        * This also means that we have not inserted the current entry to the direent buffer.
-        */
-        if (entsize > rem)
-        {
-            break;
-        }
-
-        //num_entries_returned_in_this_iter++;
-
-        // Increment the buffer pointer to point to the next free space.
-        current_buf += entsize;
-        rem -= entsize;
-        num_of_entries_returned++;
-    }
-
-    AZLogDebug("Num of entries sent in readdir response is {}", num_of_entries_returned);
-    fuse_reply_buf(get_req(),
-                   buf1,
-                   size - rem);
-
-    free(buf1);
-}
-
-
-void rpc_task::run_readdirplus()
-{
-   // bool rpc_retry = false;
-   // auto inode = rpc_api.readdirplus_task.get_inode();
-    get_readdirplus_entries_from_cache();
-
-#if 0
-    do {
-        struct READDIRPLUS3args args;
-        ::memset(&args, 0, sizeof(args));
-        args.dir = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
-        args.cookie = rpc_api.readdirplus_task.get_cookie();
-        ::memcpy(&args.cookieverf, rpc_api.readdirplus_task.get_cookieverf(), sizeof(args.cookieverf));
-        args.dircount = 65536; // TODO: See what this value should be set to.
-        args.maxcount = 65536;
-
-        if (rpc_nfs3_readdirplus_task(get_rpc_ctx(), readdirplus_callback, &args, this) == NULL)
-        {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
-            rpc_retry = true;
-        }
-    } while (rpc_retry);
-#endif
 }

--- a/nfs/src/rpc_task.cpp
+++ b/nfs/src/rpc_task.cpp
@@ -653,8 +653,8 @@ void rpc_task::fetch_readdir_entries_from_server()
         args.dir = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
         args.cookie = cookie;
         ::memcpy(&args.cookieverf, get_client()->get_nfs_inode_from_ino(inode)->dircache_handle->get_cookieverf(), sizeof(args.cookieverf));
-        args.dircount = 65536; // TODO: Set this to user passed value.
-        args.maxcount = 65536;
+        args.dircount = 1048576; // TODO: Set this to user passed value.
+        args.maxcount = 1048576;
 
         if (rpc_nfs3_readdirplus_task(get_rpc_ctx(), readdirplus_callback, &args, this) == NULL)
         {
@@ -677,7 +677,7 @@ void rpc_task::send_readdir_response(std::vector<directory_entry*>& readdirentri
     char *buf1 = (char *)malloc(size);
     if (!buf1)
     {
-        fuse_reply_err(get_req(), ENOMEM);
+        reply_error(ENOMEM);
         return;
     }
 
@@ -735,6 +735,7 @@ void rpc_task::send_readdir_response(std::vector<directory_entry*>& readdirentri
                    size - rem);
 
     free(buf1);
+    free_rpc_task();
 }
 
 void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdirentries)
@@ -745,7 +746,7 @@ void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdire
     char *buf1 = (char *)malloc(sz);
     if (!buf1)
     {
-        fuse_reply_err(get_req(), ENOMEM);
+        reply_error(ENOMEM);
         return;
     }
 
@@ -813,4 +814,5 @@ void rpc_task::send_readdirplus_response(std::vector<directory_entry*>& readdire
 
     // Free the buffer.
     free(buf1);
+    free_rpc_task();
 }

--- a/nfs/src/rpc_task.cpp
+++ b/nfs/src/rpc_task.cpp
@@ -421,7 +421,14 @@ void rpc_task::set_readdir(struct nfs_client* clt,
     rpc_api.readdir_task.set_offset(offset);
     rpc_api.readdir_task.set_fuse_file(file);
     rpc_api.readdir_task.set_cookie(offset);
-    rpc_api.readdir_task.set_cookieverf(0);
+
+    m_readdirentries.clear();
+    readdir_result_size = 0;
+    //rpc_api.readdir_task.set_cookieverf(0);
+    //rpc_api.readdir_task.m_results.clear();
+    //rpc_api.readdir_task.result_size = 0;
+    // rpc_api.readdir_task.set_buffer(nullptr);
+    //rpc_api.readdir_task.set_buffer_size(0);
 }
 
 void rpc_task::set_readdirplus(struct nfs_client* clt,
@@ -440,183 +447,24 @@ void rpc_task::set_readdirplus(struct nfs_client* clt,
     rpc_api.readdirplus_task.set_fuse_file(file);
     // rpc_api.readdirplus_task.set_cookieverf(0);
     rpc_api.readdirplus_task.set_cookie(offset);
+    m_readdirentries.clear();
+    readdir_result_size = 0;
+    //rpc_api.readdir_task.m_results.clear();
+    //rpc_api.readdir_task.result_size = 0;
 }
 
-static void getattr_callback(
-    struct rpc_context* /* rpc */,
-    int rpc_status,
-    void* data,
-    void* private_data)
-{
-    auto task = (rpc_task*)private_data;
-    auto res = (GETATTR3res*)data;
-    bool retry;
 
-    if (task->succeeded(rpc_status, RSTATUS(res), retry))
-    {
-        struct stat st;
-        task->get_client()->stat_from_fattr3(
-            &st, &res->GETATTR3res_u.resok.obj_attributes);
 
-        // TODO: Set the Attr timeout to a better value.
-        task->reply_attr(&st, 60/*getAttrTimeout()*/);
-    }
-    else if (retry)
-    {
-        task->run_getattr();
-    }
-    else
-    {
-        // Since the api failed and can no longer be retried, return error reply.
-        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
-    }
-}
-
-static void lookup_callback(
-    struct rpc_context* /* rpc */,
-    int rpc_status,
-    void* data,
-    void* private_data) {
-    auto task = (rpc_task*)private_data;
-    auto res = (LOOKUP3res*)data;
-    bool retry;
-
-    if (rpc_status == RPC_STATUS_SUCCESS && RSTATUS(res) == NFS3ERR_NOENT)
-    {
-        //
-        // Special case for fuse: A "negative entry" refers to an entry that doesn't exist
-        // in the file system. If we want negative cache, we must not return ENOENT,
-        // instead we should return success with zero inode.
-        // When the FUSE kernel module receives a negative entry response, it may cache this
-        // information for a certain duration specified by the entry_timeout parameter.
-        // This caching helps to improve performance by avoiding repeated lookup requests
-        // for entries that are known not to exist.
-        //
-        struct fattr3 dummyAttr;
-        ::memset(&dummyAttr, 0, sizeof(dummyAttr));
-
-        task->get_client()->reply_entry(
-            task,
-            nullptr /* fh */,
-            &dummyAttr,
-            nullptr);
-    }
-    else if(task->succeeded(rpc_status, RSTATUS(res), retry))
-    {
-        assert(res->LOOKUP3res_u.resok.obj_attributes.attributes_follow);
-
-        task->get_client()->reply_entry(
-            task,
-            &res->LOOKUP3res_u.resok.object,
-            &res->LOOKUP3res_u.resok.obj_attributes.post_op_attr_u.attributes,
-            nullptr);
-    }
-    else if(retry)
-    {
-        task->run_lookup();
-    }
-    else
-    {
-        // Since the api failed and can no longer be retried, return error reply.
-        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
-    }
-}
-
-static void createfile_callback(
-    struct rpc_context* /* rpc */,
-    int rpc_status,
-    void* data,
-    void* private_data)
-{
-    auto task = (rpc_task*)private_data;
-    auto res = (CREATE3res*)data;
-    bool retry;
-
-    if (task->succeeded(rpc_status, RSTATUS(res), retry, false))
-    {
-        assert(
-            res->CREATE3res_u.resok.obj.handle_follows &&
-            res->CREATE3res_u.resok.obj_attributes.attributes_follow);
-
-        task->get_client()->reply_entry(
-            task,
-            &res->CREATE3res_u.resok.obj.post_op_fh3_u.handle,
-            &res->CREATE3res_u.resok.obj_attributes.post_op_attr_u.attributes,
-            task->rpc_api.create_task.get_file());
-    }
-    else if (retry)
-    {
-        task->run_create_file();
-    }
-    else
-    {
-        // Since the api failed and can no longer be retried, return error reply.
-        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
-    }
-}
-
-static void setattr_callback(
-    struct rpc_context* /* rpc */,
-    int rpc_status,
-    void* data,
-    void* private_data)
-{
-    auto task = (rpc_task*)private_data;
-    auto res = (SETATTR3res*)data;
-    bool retry;
-
-    if (task->succeeded(rpc_status, RSTATUS(res), retry))
-    {
-        assert(res->SETATTR3res_u.resok.obj_wcc.after.attributes_follow);
-
-        struct stat st;
-        task->get_client()->stat_from_fattr3(
-            &st, &res->SETATTR3res_u.resok.obj_wcc.after.post_op_attr_u.attributes);
-        task->reply_attr(&st, 60 /* TODO: Set reasonable value nfs_client::getAttrTimeout() */);
-    }
-    else if (retry)
-    {
-        task->run_setattr();
-    }
-    else
-    {
-        // Since the api failed and can no longer be retried, return error reply.
-        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
-    }
-}
-
-void mkdir_callback(
-    struct rpc_context* /* rpc */,
-    int rpc_status,
-    void* data,
-    void* private_data) {
-    auto task = (rpc_task*)private_data;
-    auto res = (MKDIR3res*)data;
-    bool retry;
-
-    if (task->succeeded(rpc_status, RSTATUS(res), retry, false))
-    {
-        assert(
-            res->MKDIR3res_u.resok.obj.handle_follows &&
-            res->MKDIR3res_u.resok.obj_attributes.attributes_follow);
-
-        task->get_client()->reply_entry(
-            task,
-            &res->MKDIR3res_u.resok.obj.post_op_fh3_u.handle,
-            &res->MKDIR3res_u.resok.obj_attributes.post_op_attr_u.attributes,
-            nullptr);
-    }
-    else if (retry)
-    {
-        task->run_mkdir();
-    }
-    else
-    {
-        // Since the api failed and can no longer be retried, return error reply.
-        task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
-    }
-}
-
+/*
+ * For both application issued readdir and readdirplus calls, this callback will be invoked since we always
+ * issue readdirplus calls to the backend. This is done to populate the readdir cache.
+ * Once this callback is called, it will first populate the readdir cache with the newly fetched entries.
+ * Then, it will check for the optype of the rpc_task.
+ * If the optyoe is FUSE_READDIRPLUS then it will populate the directory_results vector
+ * of the readdirplus task and call send_readdirplus_response.
+ * If the optype is FUSE_READDIR  then it will populate the directory_results vector of
+ * the readdir task and call send_readdir_response.
+ */
 static void readdirplus_callback(
     struct rpc_context* /* rpc */,
     int rpc_status,
@@ -626,11 +474,27 @@ static void readdirplus_callback(
     auto task = (rpc_task*)private_data;
     auto res = (READDIRPLUS3res*)data;
     bool retry;
+    bool is_readdirplus_call = false;
+    fuse_ino_t inode;
 
-    cookie3 last_cookie = 0;
+    AZLogInfo("Entry: result_vector: {}", task->m_readdirentries.size());
+
+
+    // Check if the application asked for readdir or readdirplus call.
+    if (task->get_op_type() == FUSE_READDIRPLUS)
+    {
+        inode = task->rpc_api.readdirplus_task.get_inode();
+        is_readdirplus_call = true;
+    }
+    else
+    {
+        inode = task->rpc_api.readdir_task.get_inode();
+    }
+
 
     if (task->succeeded(rpc_status, RSTATUS(res), retry))
     {
+#if 0
         // Allocate buffer
         int num_entries_returned_in_this_iter = 0;
         size_t sz = task->rpc_api.readdirplus_task.get_size();
@@ -644,12 +508,20 @@ static void readdirplus_callback(
 
         char *current_buff = buf1;
         size_t rem = sz;
-
+#endif
         struct entryplus3* entry = res->READDIRPLUS3res_u.resok.reply.entries;
+        bool eof = res->READDIRPLUS3res_u.resok.reply.eof;
 
+
+        // Create a shared pointer to be inserted into the cache.
+        std::shared_ptr<directory_list_cache> dirlistcache_handle = task->get_client()->get_readdir_cache()->get(inode);
+        assert(dirlistcache_handle != nullptr);
+        int num_of_ele = 0;
         while (entry)
         {
-        last_cookie = entry->cookie;
+#if 0
+            last_cookie = entry->cookie;
+
             if ((int)entry->cookie <= (int)task->rpc_api.readdirplus_task.get_offset())
             {
                 AZLogDebug("skipping cookie {}", entry->cookie);
@@ -660,7 +532,7 @@ static void readdirplus_callback(
                 entry = entry->nextentry;
                 continue;
             }
-
+#endif
             // Structure to hold the attributes.
             struct stat st;
             if (entry->name_attributes.attributes_follow)
@@ -673,67 +545,129 @@ static void readdirplus_callback(
                 ::memset(&st, 0, sizeof(st));
             }
 
-            // Create a new inode for the entry
+            // Create a new nfs inode for the entry
             nfs_inode* nfs_ino;
             nfs_ino = new nfs_inode(&entry->name_handle.post_op_fh3_u.handle);
             nfs_ino->set_inode((fuse_ino_t)nfs_ino);
 
-            struct fuse_entry_param fuseentry;
-            memset(&fuseentry, 0, sizeof(fuseentry));
-            fuseentry.attr = st;
-            fuseentry.ino = (fuse_ino_t)(uintptr_t)nfs_ino;
-
             /*
-             * TODO: Set the timeout to better value.
+             * Create the directory entries here.
+             * Note: This will be freed in the destructor ~directory_list_cache().
              */
-            fuseentry.attr_timeout = 60;
-            fuseentry.entry_timeout = 60;
+            struct directory_entry* dir_entry = new directory_entry(entry->name, entry->cookie, st, nfs_ino);
 
-            /*
-             * Insert the entry into the buffer.
-             * If the buffer space is less, fuse_add_direntry_plus will not add entry to
-             * the buffer but will still return the space needed to add this entry.
-             */
-            size_t entsize = fuse_add_direntry_plus(task->get_req(),
-                                                    current_buff,
-                                                    rem, /* size left in the buffer */
-                                                    entry->name,
-                                                    &fuseentry,
-                                                    entry->cookie);
-
-            /*
-             * Our buffer size was small and hence we can't add any more entries, so just break the loop.
-             * This also means that we have not inserted the current entry to the direent buffer.
-             */
-            if (entsize > rem)
+            size_t rem_size = 0;
+            if (is_readdirplus_call)
             {
-                AZLogDebug("No isze in buf, returning");
-                break;
+                rem_size = task->rpc_api.readdirplus_task.get_size();
+            }
+            else
+            {
+                rem_size = task->rpc_api.readdir_task.get_size();
             }
 
-            num_entries_returned_in_this_iter++;
+            // Add it to the directory_entry vector if it does not cross the max size limit requested by the application.
+            const size_t curr_entry_size = dir_entry->get_size();
+            if (rem_size >= curr_entry_size)
+            {
+                    task->readdir_result_size += curr_entry_size;
+                    task->m_readdirentries.push_back(dir_entry);
 
-            // Increment the buffer pointer to point to the next free space.
-            current_buff += entsize;
-            rem -= entsize;
+                    rem_size -= curr_entry_size;
+            }
 
-            // Fetch the next entry.
+            // Add this to the directory_list_cache.
+            dirlistcache_handle->add(dir_entry);
             entry = entry->nextentry;
+
+            // TODO: Remove this.
+            ++num_of_ele;
         }
 
-        AZLogDebug("Last cookie {}", last_cookie);
+        AZLogInfo("Num of entries returned by server is {}, result_vector: {}", num_of_ele, task->m_readdirentries.size());
 
-        fuse_reply_buf(task->get_req(),
-                       buf1,
-                       sz - rem);
+        // TODO: See if the cache really needs to store the cookie verifier.
+        dirlistcache_handle->set_cookieverf(&res->READDIRPLUS3res_u.resok.cookieverf);
 
-        // Free the buffer.
-        free(buf1);
+        // Update this cookie verifier received in the inode.
+        task->get_client()->get_nfs_inode_from_ino(inode)->set_cookieverf(&res->READDIRPLUS3res_u.resok.cookieverf);
+
+        if (eof)
+        {
+            dirlistcache_handle->set_eof();
+        }
+
+        // Now insert into the readdir cache.
+        // THIS IS NOT NEEDED SINCE WE ARE DIRECTLY MODIFYING THE SHARED POINTER.
+        //read_dir_cache->add(inode, dir_cache);
+
+        if (is_readdirplus_call)
+        {
+            task->send_readdirplus_response();
+        }
+        else
+        {
+            task->send_readdir_response();
+        }
     }
-    else if (retry)
-    {
-        task->run_readdirplus();
+#if 0
+        // Create a new inode for the entry
+        nfs_inode* nfs_ino;
+        nfs_ino = new nfs_inode(&entry->name_handle.post_op_fh3_u.handle);
+        nfs_ino->set_inode((fuse_ino_t)nfs_ino);
+
+        struct fuse_entry_param fuseentry;
+        memset(&fuseentry, 0, sizeof(fuseentry));
+        fuseentry.attr = st;
+        fuseentry.ino = (fuse_ino_t)(uintptr_t)nfs_ino;
+
+        /*
+         * TODO: Set the timeout to better value.
+         */
+        fuseentry.attr_timeout = 60;
+        fuseentry.entry_timeout = 60;
+
+        /*
+         * Insert the entry into the buffer.
+         * If the buffer space is less, fuse_add_direntry_plus will not add entry to
+         * the buffer but will still return the space needed to add this entry.
+         */
+        size_t entsize = fuse_add_direntry_plus(task->get_req(),
+                                                current_buff,
+                                                rem, /* size left in the buffer */
+                                                entry->name,
+                                                &fuseentry,
+                                                entry->cookie);
+
+        /*
+         * Our buffer size was small and hence we can't add any more entries, so just break the loop.
+         * This also means that we have not inserted the current entry to the direent buffer.
+         */
+        if (entsize > rem)
+        {
+            AZLogDebug("No isze in buf, returning");
+            break;
+        }
+
+        num_entries_returned_in_this_iter++;
+
+        // Increment the buffer pointer to point to the next free space.
+        current_buff += entsize;
+        rem -= entsize;
+
+        // Fetch the next entry.
+        entry = entry->nextentry;
     }
+
+    AZLogDebug("Last cookie {}", last_cookie);
+
+    fuse_reply_buf(task->get_req(),
+                   buf1,
+                   sz - rem);
+
+    // Free the buffer.
+    free(buf1);
+#endif
     else
     {
         // Since the api failed and can no longer be retried, return error reply.
@@ -741,6 +675,146 @@ static void readdirplus_callback(
     }
 }
 
+#if 0
+rpc_task::send_readdir_response()
+{
+    size_t sz = rpc_api.readdir_task.get_size();
+
+    char *buf1 = (char *)malloc(sz);
+    if (!buf1)
+    {
+        fuse_reply_err(get_req(), ENOMEM);
+        return;
+    }
+
+
+    char *current_buff = buf1;
+    size_t rem = sz;
+
+
+    for (auto it = rpc_api.readdir_task.m_results.begin(); it != rpc_api.readdir_task.m_results.end(); ++it)
+    {
+        if ((int)it->cookie <= (int)rpc_api.readdir_task.get_offset())
+        {
+            /*
+             * Skip entries until the offset
+             * TODO: See if we need this. Can't we control this thorugh the cookie?
+             */
+            entry = entry->nextentry;
+            AZLogDebug("skipping cookie {}", entry->cookie);
+            continue;
+        }
+
+
+
+        /*
+         * Insert the entry into the buffer.
+         * If the buffer space is less, fuse_add_direntry will not add entry to
+         * the buffer but will still return the space needed to add this entry.
+         */
+        size_t entsize = fuse_add_direntry(get_req(),
+                                           current_buf,
+                                           rem, /* size left in the buffer */
+                                           it->name,
+                                           &it->attributes,
+                                           it->cookie);
+
+        /*
+         * Our buffer size was small and hence we can't add any more entries, so just break the loop.
+         * This also means that we have not inserted the current entry to the direent buffer.
+         */
+        if (entsize > rem)
+        {
+            break;
+        }
+
+        // Increment the buffer pointer to point to the next free space.
+        current_buf += entsize;
+        rem -= entsize;
+    }
+}
+#endif
+
+void rpc_task::send_readdirplus_response()
+{
+    size_t sz = rpc_api.readdirplus_task.get_size();
+
+    char *buf1 = (char *)malloc(sz);
+    if (!buf1)
+    {
+        fuse_reply_err(get_req(), ENOMEM);
+        return;
+    }
+
+
+    char *current_buf = buf1;
+    size_t rem = sz;
+    int num_of_entries_returned = 0;
+
+    AZLogInfo("Size of readdirplus result vector is {}", m_readdirentries.size());
+    //for ( auto it = m_readdirentries.begin(); it != m_readdirentries.end(); ++it)
+    for (const auto& it : m_readdirentries)
+    {
+        if ((int)it->cookie <= (int)rpc_api.readdirplus_task.get_offset())
+        {
+            /*
+             * Skip entries until the offset
+             * TODO: See if we need this. Can't we control this thorugh the cookie?
+             */
+           // entry = entry->nextentry;
+            AZLogDebug("skipping cookie {}", it->cookie);
+            continue;
+        }
+
+        struct fuse_entry_param fuseentry;
+        memset(&fuseentry, 0, sizeof(fuseentry));
+        fuseentry.attr = it->attributes;
+        fuseentry.ino = it->nfs_ino->inode;
+
+        /*
+         * TODO: Set the timeout to better value.
+         */
+        fuseentry.attr_timeout = 60;
+        fuseentry.entry_timeout = 60;
+
+        /*
+         * Insert the entry into the buffer.
+         * If the buffer space is less, fuse_add_direntry_plus will not add entry to
+         * the buffer but will still return the space needed to add this entry.
+         */
+        size_t entsize = fuse_add_direntry_plus(get_req(),
+                                                current_buf,
+                                                rem, /* size left in the buffer */
+                                                it->name,
+                                                &fuseentry,
+                                                it->cookie);
+
+        /*
+         * Our buffer size was small and hence we can't add any more entries, so just break the loop.
+         * This also means that we have not inserted the current entry to the direent buffer.
+         */
+        if (entsize > rem)
+        {
+            AZLogDebug("No isze in buf, returning");
+            break;
+        }
+
+        // Increment the buffer pointer to point to the next free space.
+        current_buf += entsize;
+        rem -= entsize;
+        num_of_entries_returned++;
+    }
+
+    AZLogDebug("Num of entries sent in readdirplus response is {}", num_of_entries_returned);
+    fuse_reply_buf(get_req(),
+                   buf1,
+                   sz - rem);
+
+    // Free the buffer.
+    free(buf1);
+}
+
+#if 0
 static void readdir_callback(
     struct rpc_context* /* rpc */,
     int rpc_status,
@@ -835,178 +909,12 @@ static void readdir_callback(
         task->reply_error(-nfsstat3_to_errno(RSTATUS(res)));
     }
 }
-
-void rpc_task::run_lookup()
-{
-    bool rpc_retry = false;
-    auto parent_ino = rpc_api.lookup_task.get_parent_inode();
-
-    do {
-        LOOKUP3args args;
-        ::memset(&args, 0, sizeof(args));
-        args.what.dir = get_client()->get_nfs_inode_from_ino(parent_ino)->get_fh();
-        args.what.name = (char*)rpc_api.lookup_task.get_name();
-
-        if (rpc_nfs3_lookup_task(get_rpc_ctx(), lookup_callback, &args, this) == NULL)
-        {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
-            rpc_retry = true;
-        }
-    } while (rpc_retry);
-}
-
-void rpc_task::run_getattr()
-{
-    bool rpc_retry = false;
-    auto inode = rpc_api.getattr_task.get_inode();
-
-    do {
-        struct GETATTR3args args;
-        ::memset(&args, 0, sizeof(args));
-        args.object = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
-
-        if (rpc_nfs3_getattr_task(get_rpc_ctx(), getattr_callback, &args, this) == NULL)
-        {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
-            rpc_retry = true;
-        }
-    } while (rpc_retry);
-}
-
-void rpc_task::run_create_file()
-{
-    bool rpc_retry = false;
-    auto parent_ino = rpc_api.create_task.get_parent_inode();
-
-    do {
-        CREATE3args args;
-        ::memset(&args, 0, sizeof(args));
-        args.where.dir = get_client()->get_nfs_inode_from_ino(parent_ino)->get_fh();
-        args.where.name = (char*)rpc_api.create_task.get_name();
-        args.how.mode = (rpc_api.create_task.get_file()->flags & O_EXCL) ? GUARDED : UNCHECKED;
-        args.how.createhow3_u.obj_attributes.mode.set_it = 1;
-        args.how.createhow3_u.obj_attributes.mode.set_mode3_u.mode = rpc_api.create_task.get_mode();
-
-        if (rpc_nfs3_create_task(get_rpc_ctx(), createfile_callback, &args, this) == NULL)
-        {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
-            rpc_retry = true;
-        }
-    }  while (rpc_retry);
-}
-
-void rpc_task::run_mkdir()
-{
-    bool rpc_retry = false;
-    auto parent_ino = rpc_api.mkdir_task.get_parent_inode();
-
-    do {
-        MKDIR3args args;
-        ::memset(&args, 0, sizeof(args));
-        args.where.dir = get_client()->get_nfs_inode_from_ino(parent_ino)->get_fh();
-        args.where.name = (char*)rpc_api.mkdir_task.get_name();
-        args.attributes.mode.set_it = 1;
-        args.attributes.mode.set_mode3_u.mode = rpc_api.mkdir_task.get_mode();
-
-
-        if (rpc_nfs3_mkdir_task(get_rpc_ctx(), mkdir_callback, &args, this) == NULL)
-        {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
-            rpc_retry = true;
-        }
-    } while (rpc_retry);
-}
-
-void rpc_task::run_setattr()
-{
-    auto inode = rpc_api.setattr_task.get_inode();
-    auto attr = rpc_api.setattr_task.get_attr();
-    const int valid = rpc_api.setattr_task.get_attr_flags_to_set();
-    bool rpc_retry = false;
-
-    do {
-        SETATTR3args args;
-        ::memset(&args, 0, sizeof(args));
-        args.object = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
-
-        if (valid & FUSE_SET_ATTR_SIZE) {
-            AZLogInfo("Setting size to {}", attr->st_size);
-
-            args.new_attributes.size.set_it = 1;
-            args.new_attributes.size.set_size3_u.size = attr->st_size;
-        }
-
-        if (valid & FUSE_SET_ATTR_MODE) {
-            AZLogInfo("Setting mode to {}", attr->st_mode);
-
-            args.new_attributes.mode.set_it = 1;
-            args.new_attributes.mode.set_mode3_u.mode = attr->st_mode;
-        }
-
-        if (valid & FUSE_SET_ATTR_UID) {
-            AZLogInfo("Setting uid to {}", attr->st_uid);
-            args.new_attributes.uid.set_it = 1;
-            args.new_attributes.uid.set_uid3_u.uid = attr->st_uid;
-        }
-
-        if (valid & FUSE_SET_ATTR_GID) {
-            AZLogInfo("Setting gid to {}", attr->st_gid);
-
-            args.new_attributes.gid.set_it = 1;
-            args.new_attributes.gid.set_gid3_u.gid = attr->st_gid;
-        }
-
-        if (valid & FUSE_SET_ATTR_ATIME) {
-            // TODO: These log are causing crash, look at it later.
-            // AZLogInfo("Setting atime to {}", attr->st_atim.tv_sec);
-
-            args.new_attributes.atime.set_it = SET_TO_CLIENT_TIME;
-            args.new_attributes.atime.set_atime_u.atime.seconds =
-                attr->st_atim.tv_sec;
-            args.new_attributes.atime.set_atime_u.atime.nseconds =
-                attr->st_atim.tv_nsec;
-        }
-
-        if (valid & FUSE_SET_ATTR_MTIME) {
-            // TODO: These log are causing crash, look at it later.
-            // AZLogInfo("Setting mtime to {}", attr->st_mtim.tv_sec);
-
-            args.new_attributes.mtime.set_it = SET_TO_CLIENT_TIME;
-            args.new_attributes.mtime.set_mtime_u.mtime.seconds =
-                attr->st_mtim.tv_sec;
-            args.new_attributes.mtime.set_mtime_u.mtime.nseconds =
-                attr->st_mtim.tv_nsec;
-        }
-
-        if (valid & FUSE_SET_ATTR_ATIME_NOW) {
-            AZLogInfo("Setting atime to now");
-            args.new_attributes.atime.set_it = SET_TO_SERVER_TIME;
-        }
-
-        if (valid & FUSE_SET_ATTR_MTIME_NOW) {
-            AZLogInfo("Setting mtime to now");
-            args.new_attributes.mtime.set_it = SET_TO_SERVER_TIME;
-        }
-
-        if (rpc_nfs3_setattr_task(get_rpc_ctx(), setattr_callback, &args, this) == NULL)
-        {
-            // This call fails due to internal issues like OOM etc
-            // and not due to an actual error, hence retry.
-            rpc_retry = true;
-        }
-    } while (rpc_retry);
-}
+#endif
 
 void rpc_task::run_readdir()
 {
-
-    bool rpc_retry = false;
-    auto inode = rpc_api.readdir_task.get_inode();
-
+    get_readdir_entries_from_cache();
+#if 0
     do {
         struct READDIR3args args;
         ::memset(&args, 0, sizeof(args));
@@ -1022,13 +930,196 @@ void rpc_task::run_readdir()
             rpc_retry = true;
         }
     } while (rpc_retry);
+#endif
 }
+
+void rpc_task::get_readdir_entries_from_cache()
+{
+    auto readdircache = get_client()->get_readdir_cache();
+    bool is_eof = false;
+
+    /*const bool entry_found =*/ readdircache->lookup(rpc_api.readdir_task.get_inode(),
+                         rpc_api.readdir_task.get_cookie(), // TODO: See if this should populate from cookie+1
+                         rpc_api.readdir_task.get_size(),
+                         m_readdirentries,
+                         readdir_result_size,
+                         //rpc_api.readdir_task.m_results,
+                         //rpc_api.readdir_task.result_size,
+                         is_eof);
+#if 0
+    if (!entry_found)
+    {
+        assert (m_readdirentries.empty());
+        assert (readdir_result_size == 0);
+        fetch_readdir_entries_from_server();
+    }
+ #endif
+    if ((rpc_api.readdir_task.get_size() > readdir_result_size)/* && !is_eof*/)
+    {
+        /*
+         * We can return more number of entries to the caller since we have not exceeded the
+         * requested size. Since these entries are not present in the cache, this should be fetched
+         * from the backend.
+         */
+        fetch_readdir_entries_from_server();
+    }
+    else
+    {
+        // We are done fetching all the entries, send the response now.
+        send_readdir_response();
+    }
+}
+
+void rpc_task::get_readdirplus_entries_from_cache()
+{
+    auto readdircache = get_client()->get_readdir_cache();
+    bool is_eof = false;
+
+    readdircache->lookup(rpc_api.readdirplus_task.get_inode(),
+                         rpc_api.readdirplus_task.get_cookie(),
+                         rpc_api.readdirplus_task.get_size(),
+                         m_readdirentries,
+                         readdir_result_size,
+                         //rpc_api.readdirplus_task.m_results,
+                         //rpc_api.readdirplus_task.result_size,
+                         is_eof);
+
+    if ((rpc_api.readdirplus_task.get_size() > readdir_result_size) && !is_eof)
+    {
+        /*
+         * We can return more number of entries to the caller since we have not exceeded the
+         * requested size. Since these entries are not present in the cache, this should be fetched
+         * from the backend.
+         */
+        fetch_readdir_entries_from_server();
+    }
+    else
+    {
+        send_readdirplus_response();
+    }
+}
+
+void rpc_task::fetch_readdir_entries_from_server()
+{
+    bool rpc_retry = false;
+    fuse_ino_t inode;
+
+    if (get_op_type() == FUSE_READDIR)
+    {
+        inode = rpc_api.readdir_task.get_inode();
+        //cookie = rpc_api.readdir_task.m_results.back().cookie;
+    }
+    else
+    {
+         inode = rpc_api.readdirplus_task.get_inode();
+        //cookie = rpc_api.readdirplus_task.m_results.back().cookie;
+    }
+
+    cookie3 cookie = 0;
+
+    // Fetch the cookie from where we want to do the listing.
+    if (!m_readdirentries.empty())
+    {
+        cookie = m_readdirentries.back()->cookie;
+    }
+    
+    do {
+        struct READDIRPLUS3args args;
+        ::memset(&args, 0, sizeof(args));
+        args.dir = get_client()->get_nfs_inode_from_ino(inode)->get_fh();
+        //args.cookie = rpc_api.readdirplus_task.get_cookie();
+        args.cookie = cookie;
+        ::memcpy(&args.cookieverf, get_client()->get_nfs_inode_from_ino(inode)->get_cookieverf(), sizeof(args.cookieverf));
+       // ::memcpy(&args.cookieverf, cookieverf, sizeof(args.cookieverf));
+        args.dircount = 65536; // TODO: See what this value should be set to.
+        args.maxcount = 65536;
+
+        if (rpc_nfs3_readdirplus_task(get_rpc_ctx(), readdirplus_callback, &args, this) == NULL)
+        {
+            // This call fails due to internal issues like OOM etc
+            // and not due to an actual error, hence retry.
+            rpc_retry = true;
+        }
+    } while (rpc_retry);
+
+}
+
+void rpc_task::send_readdir_response()
+{
+    const size_t size = rpc_api.readdir_task.get_size();
+    // Allocate buffer
+    char *buf1 = (char *)malloc(size);
+    if (!buf1)
+    {
+        fuse_reply_err(get_req(), ENOMEM);
+        return;
+    }
+
+    char *current_buf = buf1;
+    size_t rem = size;
+    int  num_of_entries_returned = 0;
+    AZLogInfo("Size of readdir result vector is {}", m_readdirentries.size());
+
+    for (const auto& it : m_readdirentries)
+    {
+        AZLogInfo("Curr entry readdir cookie is {}", it->cookie);
+        if ((int)it->cookie <= (int)rpc_api.readdir_task.get_offset())
+        {
+            /*
+             * Skip entries until the offset
+             * TODO: See if we need this. Can't we control this thorugh the cookie?
+             */
+           // entry = entry->nextentry;
+            AZLogDebug("skipping cookie {}", it->cookie);
+            continue;
+        }
+        /*
+        * Insert the entry into the buffer.
+        * If the buffer space is less, fuse_add_direntry will not add entry to
+        * the buffer but will still return the space needed to add this entry.
+        */
+        struct stat st;
+        ::memset(&st, 0, sizeof(st));
+        size_t entsize = fuse_add_direntry(get_req(),
+                                           current_buf,
+                                           rem, /* size left in the buffer */
+                                           it->name,
+                                           &st, // TODO: Should we not pass attributes for readdir?
+                                           it->cookie);
+
+        /*
+        * Our buffer size was small and hence we can't add any more entries, so just break the loop.
+        * This also means that we have not inserted the current entry to the direent buffer.
+        */
+        if (entsize > rem)
+        {
+            break;
+        }
+
+        //num_entries_returned_in_this_iter++;
+
+        // Increment the buffer pointer to point to the next free space.
+        current_buf += entsize;
+        rem -= entsize;
+        num_of_entries_returned++;
+    }
+
+    AZLogDebug("Num of entries sent in readdir response is {}", num_of_entries_returned);
+    fuse_reply_buf(get_req(),
+                   buf1,
+                   size - rem);
+
+    free(buf1);
+}
+
 
 void rpc_task::run_readdirplus()
 {
-    bool rpc_retry = false;
-    auto inode = rpc_api.readdirplus_task.get_inode();
+   // bool rpc_retry = false;
+   // auto inode = rpc_api.readdirplus_task.get_inode();
+    get_readdir_entries_from_cache();
 
+#if 0
     do {
         struct READDIRPLUS3args args;
         ::memset(&args, 0, sizeof(args));
@@ -1045,4 +1136,5 @@ void rpc_task::run_readdirplus()
             rpc_retry = true;
         }
     } while (rpc_retry);
+#endif
 }


### PR DESCRIPTION
This is a byte-range cache which allows us to cache arbitrary byte ranges from a file. Readers and writers can use the get() API to get a vector of byte ranges that make up a bigger range. After the get() call gives you a std::vector<bytes_chunk> you can go over the various bytes_chunk and read/write data into those buffers (which is like a scatter/gather list). Read comments in the .h file for more details.